### PR TITLE
Restore KMS caching logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.6
+
+### Minor Changes
+
+(nothing yet)
+
 ## 1.3.5
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 1.3.5
 
-(nothing yet)
+### Minor Changes
+
+* Restored the KMS client cache with a fix for the memory leak.
 
 ## 1.3.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Minor Changes
 
 * Restored the KMS client cache with a fix for the memory leak.
+* When using a master key provider that can only service a subset of regions
+(e.g. using the deprecated constructors), and requesting a master key from a
+region not servicable by that MKP, the exception will now be thrown on first
+use of the MK, rather than at getMasterKey time.
 
 ## 1.3.4
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can get the latest release from Maven:
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-encryption-sdk-java</artifactId>
-  <version>1.3.4</version>
+  <version>1.3.5</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.3.5</version>
+    <version>1.3.6-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.3.5-SNAPSHOT</version>
+    <version>1.3.5</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -26,7 +26,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Request;
+import com.amazonaws.Response;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
@@ -71,11 +74,15 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
         AWSKMS getClient(String regionName);
     }
 
-    public static final class Builder implements Cloneable {
+    public static class Builder implements Cloneable {
         private String defaultRegion_ = null;
         private RegionalClientSupplier regionalClientSupplier_ = null;
         private AWSKMSClientBuilder templateBuilder_ = null;
         private List<String> keyIds_ = new ArrayList<>();
+
+        Builder() {
+            // Default access: Don't allow outside classes to extend this class
+        }
 
         public Builder clone() {
             try {
@@ -259,10 +266,67 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
             AWSKMSClientBuilder builder = templateBuilder_ != null ? cloneClientBuilder(templateBuilder_)
                                                                    : AWSKMSClientBuilder.standard();
 
+            ConcurrentHashMap<String, AWSKMS> clientCache = new ConcurrentHashMap<>();
+            snoopClientCache(clientCache);
+
             return region -> {
-                // Clone yet again as we're going to change the region field.
-                return cloneClientBuilder(builder).withRegion(region).build();
+                AWSKMS kms = clientCache.get(region);
+
+                if (kms != null) return kms;
+
+                // We can't just use computeIfAbsent as we need to avoid leaking KMS clients if we're asked to decrypt
+                // an EDK with a bogus region in its ARN. So we'll install a request handler to identify the first
+                // successful call, and cache it when we see that.
+                SuccessfulRequestCacher cacher = new SuccessfulRequestCacher(clientCache, region);
+                ArrayList<RequestHandler2> handlers = new ArrayList<>();
+                if (builder.getRequestHandlers() != null) {
+                    handlers.addAll(builder.getRequestHandlers());
+                }
+                handlers.add(cacher);
+
+                kms = cloneClientBuilder(builder)
+                        .withRegion(region)
+                        .withRequestHandlers(handlers.toArray(new RequestHandler2[handlers.size()]))
+                        .build();
+                cacher.client_ = kms;
+
+                return kms;
             };
+        }
+
+        protected void snoopClientCache(ConcurrentHashMap<String, AWSKMS> map) {
+            // no-op - this is a test hook
+        }
+    }
+
+    private static class SuccessfulRequestCacher extends RequestHandler2 {
+        private final ConcurrentHashMap<String, AWSKMS> cache_;
+        private final String region_;
+        private AWSKMS client_;
+
+        volatile boolean ranBefore_ = false;
+
+        private SuccessfulRequestCacher(
+                final ConcurrentHashMap<String, AWSKMS> cache,
+                final String region
+        ) {
+            this.region_ = region;
+            this.cache_ = cache;
+        }
+
+        @Override public void afterResponse(final Request<?> request, final Response<?> response) {
+            if (ranBefore_) return;
+            ranBefore_ = true;
+
+            cache_.putIfAbsent(region_, client_);
+        }
+
+        @Override public void afterError(final Request<?> request, final Response<?> response, final Exception e) {
+            if (ranBefore_) return;
+            if (e instanceof AmazonServiceException) {
+                ranBefore_ = true;
+                cache_.putIfAbsent(region_, client_);
+            }
         }
     }
 

--- a/src/test/java/com/amazonaws/encryptionsdk/AllTestsSuite.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AllTestsSuite.java
@@ -23,7 +23,7 @@ import com.amazonaws.encryptionsdk.model.CipherBlockHeadersTest;
 import com.amazonaws.encryptionsdk.model.CipherFrameHeadersTest;
 import com.amazonaws.encryptionsdk.model.KeyBlobTest;
 import com.amazonaws.encryptionsdk.multi.MultipleMasterKeyTest;
-import com.amazonaws.services.kms.KMSProviderBuilderMockTests;
+import com.amazonaws.encryptionsdk.kms.KMSProviderBuilderMockTests;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({

--- a/src/test/java/com/amazonaws/encryptionsdk/IntegrationTestSuite.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/IntegrationTestSuite.java
@@ -3,8 +3,8 @@ package com.amazonaws.encryptionsdk;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-import com.amazonaws.services.kms.KMSProviderBuilderIntegrationTests;
-import com.amazonaws.services.kms.XCompatKmsDecryptTest;
+import com.amazonaws.encryptionsdk.kms.KMSProviderBuilderIntegrationTests;
+import com.amazonaws.encryptionsdk.kms.XCompatKmsDecryptTest;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({

--- a/src/test/java/com/amazonaws/encryptionsdk/kms/KMSProviderBuilderMockTests.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kms/KMSProviderBuilderMockTests.java
@@ -1,8 +1,7 @@
-package com.amazonaws.services.kms;
+package com.amazonaws.encryptionsdk.kms;
 
 import static com.amazonaws.encryptionsdk.multi.MultipleProviderFactory.buildMultiProvider;
 import static com.amazonaws.regions.Region.getRegion;
-import static com.amazonaws.regions.Regions.DEFAULT_REGION;
 import static com.amazonaws.regions.Regions.fromName;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
@@ -30,8 +29,6 @@ import com.amazonaws.RequestClientOptions;
 import com.amazonaws.encryptionsdk.AwsCrypto;
 import com.amazonaws.encryptionsdk.MasterKeyProvider;
 import com.amazonaws.encryptionsdk.internal.VersionInfo;
-import com.amazonaws.encryptionsdk.kms.KmsMasterKey;
-import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
 import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider.RegionalClientSupplier;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;

--- a/src/test/java/com/amazonaws/encryptionsdk/kms/KMSTestFixtures.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kms/KMSTestFixtures.java
@@ -1,4 +1,4 @@
-package com.amazonaws.services.kms;
+package com.amazonaws.encryptionsdk.kms;
 
 final class KMSTestFixtures {
     private KMSTestFixtures() {

--- a/src/test/java/com/amazonaws/encryptionsdk/kms/LegacyKMSMasterKeyProviderTests.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kms/LegacyKMSMasterKeyProviderTests.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package com.amazonaws.services.kms;
+package com.amazonaws.encryptionsdk.kms;
 
 import static com.amazonaws.encryptionsdk.CryptoAlgorithm.ALG_AES_128_GCM_IV12_TAG16_NO_KDF;
 import static com.amazonaws.encryptionsdk.internal.RandomBytesGenerator.generate;
@@ -34,11 +34,10 @@ import com.amazonaws.encryptionsdk.MasterKey;
 import com.amazonaws.encryptionsdk.MasterKeyProvider;
 import com.amazonaws.encryptionsdk.MasterKeyRequest;
 import com.amazonaws.encryptionsdk.jce.JceMasterKey;
-import com.amazonaws.encryptionsdk.kms.KmsMasterKey;
-import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
 import com.amazonaws.encryptionsdk.multi.MultipleProviderFactory;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kms.AWSKMS;
 
 public class LegacyKMSMasterKeyProviderTests {
     private static final String WRAPPING_ALG = "AES/GCM/NoPadding";

--- a/src/test/java/com/amazonaws/encryptionsdk/kms/MockKMSClient.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kms/MockKMSClient.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package com.amazonaws.services.kms;
+package com.amazonaws.encryptionsdk.kms;
 
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
@@ -29,6 +29,7 @@ import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.ResponseMetadata;
 import com.amazonaws.regions.Region;
 import com.amazonaws.regions.Regions;
+import com.amazonaws.services.kms.AWSKMSClient;
 import com.amazonaws.services.kms.model.CreateAliasRequest;
 import com.amazonaws.services.kms.model.CreateAliasResult;
 import com.amazonaws.services.kms.model.CreateGrantRequest;

--- a/src/test/java/com/amazonaws/encryptionsdk/kms/XCompatKmsDecryptTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kms/XCompatKmsDecryptTest.java
@@ -11,7 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package com.amazonaws.services.kms;
+package com.amazonaws.encryptionsdk.kms;
 
 import static org.junit.Assert.assertArrayEquals;
 
@@ -32,7 +32,6 @@ import org.junit.runners.Parameterized.Parameters;
 
 import com.amazonaws.encryptionsdk.AwsCrypto;
 import com.amazonaws.encryptionsdk.CryptoResult;
-import com.amazonaws.encryptionsdk.kms.KmsMasterKeyProvider;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 


### PR DESCRIPTION
We now verify that the requested region is reachable before caching the KMS
client. Behavior verified by tests (for the should-not-cache case) and log inspection (for the should-cache case).