### PR TITLE
Keyblob parse exception

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/model/KeyBlob.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/model/KeyBlob.java
@@ -98,7 +98,11 @@ public final class KeyBlob implements EncryptedDataKey {
      *             length.
      */
     private int parseKeyProviderIdLen(final byte[] b, final int off) throws ParseException {
-        keyProviderIdLen_ = PrimitivesParser.parseShort(b, off);
+        short len = PrimitivesParser.parseShort(b, off);
+        if (len < 0) {
+            throw new ParseException("Parsed negative length for key provider id");
+        }
+        keyProviderIdLen_ = len;
         return Short.SIZE / Byte.SIZE;
     }
 
@@ -152,7 +156,11 @@ public final class KeyBlob implements EncryptedDataKey {
      *             length.
      */
     private int parseKeyProviderInfoLen(final byte[] b, final int off) throws ParseException {
-        keyProviderInfoLen_ = PrimitivesParser.parseShort(b, off);
+        short len = PrimitivesParser.parseShort(b, off);
+        if (len < 0) {
+            throw new ParseException("Parsed negative length for key provider info");
+        }
+        keyProviderInfoLen_ = len;
         return Short.SIZE / Byte.SIZE;
     }
 
@@ -205,7 +213,11 @@ public final class KeyBlob implements EncryptedDataKey {
      *             if there are not sufficient bytes to parse the key length.
      */
     private int parseKeyLen(final byte[] b, final int off) throws ParseException {
-        encryptedKeyLen_ = PrimitivesParser.parseShort(b, off);
+        short len = PrimitivesParser.parseShort(b, off);
+        if (len < 0) {
+            throw new ParseException("Parsed negative length for key");
+        }
+        encryptedKeyLen_ = len;
         return Short.SIZE / Byte.SIZE;
     }
 

--- a/src/test/java/com/amazonaws/encryptionsdk/model/KeyBlobTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/model/KeyBlobTest.java
@@ -15,7 +15,9 @@ package com.amazonaws.encryptionsdk.model;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
@@ -169,5 +171,52 @@ public class KeyBlobTest {
         final KeyBlob reconstructedKeyBlob = deserialize(keyBlobBytes);
 
         assertEquals(mockDataKey_.getEncryptedDataKey().length, reconstructedKeyBlob.getEncryptedDataKeyLen());
+    }
+
+    @Test
+    public void checkNegativeKeyProviderIdLen() {
+        final KeyBlob reconstruct = new KeyBlob();
+        final byte[] keyBlobBytes = createKeyBlobBytes();
+
+        // we will manually set the keyProviderIdLen to negative
+        final byte[] negativeKeyProviderIdLen = ByteBuffer.allocate(Short.BYTES)
+	    .putShort((short) -1).array();
+        System.arraycopy(negativeKeyProviderIdLen, 0, keyBlobBytes, 0, Short.BYTES);
+
+	reconstruct.deserialize(keyBlobBytes, 0);
+	// negative key provider id len throws parse exception so deserialization is incomplete
+	assertFalse(reconstruct.isComplete());
+    }
+
+    @Test
+    public void checkNegativeKeyProviderInfoLen() {
+	final KeyBlob reconstruct = new KeyBlob();
+        final byte[] keyBlobBytes = createKeyBlobBytes();
+
+        // we will manually set the keyProviderInfoLen to negative
+        final byte[] negativeKeyProviderInfoLen = ByteBuffer.allocate(Short.BYTES)
+	    .putShort((short) -1).array();
+	int offset = Short.BYTES + providerId_.length();
+        System.arraycopy(negativeKeyProviderInfoLen, 0, keyBlobBytes, offset, Short.BYTES);
+
+        reconstruct.deserialize(keyBlobBytes, 0);
+        // negative key provider info len throws parse exception so deserialization is incomplete
+        assertFalse(reconstruct.isComplete());
+    }
+
+    @Test
+    public void checkNegativeKeyLen() {
+        final KeyBlob reconstruct = new KeyBlob();
+        final byte[] keyBlobBytes = createKeyBlobBytes();
+
+        // we will manually set the keyLen to negative
+        final byte[] negativeKeyLen = ByteBuffer.allocate(Short.BYTES)
+	    .putShort((short) -1).array();
+        int offset = Short.BYTES + providerId_.length() + Short.BYTES + providerInfo_.length();
+        System.arraycopy(negativeKeyLen, 0, keyBlobBytes, offset, Short.BYTES);
+
+        reconstruct.deserialize(keyBlobBytes, 0);
+        // negative key len throws parse exception so deserialization is incomplete
+        assertFalse(reconstruct.isComplete());
     }
 }


### PR DESCRIPTION
*Issue #, if available:*
No number

*Description of changes:*
Done at the request of Rustan Leino: Currently, if the KeyBlob deserializer reads a negative length for the key provider ID, key provider info, or the key itself, this does not directly result in an exception. Instead, when the deserializer later tries to read the provider ID, provider info, or key, `Arrays.copyOfRange()` throws an `IllegalArgumentException`. From a client's perspective, this seems like a misleading exception, since the client passed all the correct arguments but the message's contents are what led to the exception. This change instead throws a `ParseException` if a negative length is read, corresponding to the line "the bytes does not properly represent the desired object" in the Javadoc for `ParseException.`

Unit tests are included that test for this case. The unit tests throw an IllegalArgumentException in the present version of the code; with the changes, they terminate normally but without deserializing the field that had a negative length. (This happens because `deserialize()` catches the `ParseException`. That may not be desired behavior in that case, since a client might retry `deserialize()`, not knowing that the message contents are what led to the failure to deserialize and thus never succeeding. Perhaps `deserialize()` should distinguish between bad message bodies versus not having enough bytes with different exceptions?)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
