### PR TITLE
JML Specifications for CipherBlockHeaders

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/model/CipherBlockHeaders.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/model/CipherBlockHeaders.java
@@ -310,13 +310,13 @@ public final class CipherBlockHeaders {
         int parsedBytes = 0;
         try {
             if (nonceLength_ > 0 && nonce_ == null) {
-                parsedBytes += parseNonce(b, off + parsedBytes);    
+                parsedBytes += parseNonce(b, off + parsedBytes);
             }
-            
+
             if (contentLength_ < 0) {
                 parsedBytes += parseContentLength(b, off + parsedBytes);
             }
-            
+
             isComplete_ = true;
         } catch (ParseException e) {
             // this results when we do partial parsing and there aren't enough


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Included are JML specifications for CipherBlockHeaders, which verify by running the development build of OpenJML. 

A pertinent issue for review might be the specification for `deserialize()` since the partial deserialization behavior is difficult to concisely state in JML; is there a simpler property that could be stated of the function and applied similarly to the other partial deserializations in the models package?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
