### PR TITLE
Run the OpenJML proof in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,10 @@ jdk:
 script: mvn install -Dgpg.skip=true
 sudo: false
 dist: trusty
+
+# Run the OpenJML proof only once, on openjdk8
+matrix:
+  include:
+    - stage: proof
+      jdk: openjdk8
+      script: jml/run-proof.sh

--- a/jml/run-proof.sh
+++ b/jml/run-proof.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e -u -o pipefail -x
+trap "kill 0" SIGINT SIGTERM
+
+mkdir -p /var/tmp/openjml{,-build}
+
+# Install OpenJML
+pushd /var/tmp/openjml-build
+git clone https://github.com/OpenJML/OpenJML.git
+cd OpenJML && git checkout e4dc6371e2cf45d1a08b5c91990e2a875f33dd27
+cp OpenJML/releaseBuilds-CI/openjml.jar /var/tmp/openjml/openjml.jar
+popd
+
+# Install Z3
+pushd /var/tmp/openjml-build
+git clone https://github.com/OpenJML/Solvers.git
+cd Solvers && git checkout 023d9682b6fa2e5d70e7587e2e293bdeae4e0885
+cp -r Solvers-linux /var/tmp/openjml
+popd
+
+# Run the OpenJML proof.  Currently we only check the annotations on the files
+# in FILES.  We will continue adding files to this list as we add annotations.
+cd src/main/java
+
+declare -a FILES=(
+  com/amazonaws/encryptionsdk/model/KeyBlob.java
+)
+
+for file in ${FILES[@]}; do
+  java -Xmx4g -jar /var/tmp/openjml/openjml.jar -- -Werror -progress -timeout 600 -esc -spec-math=bigint -code-math=safe -minQuant -no-staticInitWarning -prover z3_4_3 -sourcepath . ${file}
+done


### PR DESCRIPTION
I tested this in a fork.

*Issue #, if available:*

*Description of changes:*

Currently there are OpenJML specifications, but they are not checked during the build.  This change changes the build to have Travis check the specs in Docker.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
