### PR TITLE
Check if the given ARN is valid before to parse the region.

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -645,17 +645,18 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
     }
 
     private static String parseRegionfromKeyArn(final String keyArn) {
-        final String[] parts = keyArn.split(":", 5);
+        String region = null;
 
-        if (!parts[0].equals("arn")) {
-            // Not an arn
-            return null;
+        if (keyArn != null) {
+            final String[] parts = keyArn.split(":", 5);
+
+            // parts[1].equals("aws"); // This can vary
+            if (parts[0].equals("arn") && // Check arn
+                    parts[2].equals("kms")) { // Check kms
+                region = parts[3];
+            }
         }
-        // parts[1].equals("aws"); // This can vary
-        if (!parts[2].equals("kms")) {
-            // Not a kms arn
-            return null;
-        }
-        return parts[3]; // return region
+
+        return region;
     }
 }


### PR DESCRIPTION
When using the KMSMasterKeyBuilder or the default constructor, in the case where we don't provide the region 
 and only the key id (ARN), to infer the region we'll use the key id however if the key id is null there will be a NullPointerException which will be raised, and by default null(s) are not handled correctly on upstream operations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
