### PR TITLE
Use the BouncyCastleProvider class directly

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/CryptoAlgorithm.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/CryptoAlgorithm.java
@@ -16,7 +16,6 @@ package com.amazonaws.encryptionsdk;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.security.InvalidKeyException;
-import java.security.Provider;
 import java.security.Security;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -25,6 +24,7 @@ import java.util.Map;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import com.amazonaws.encryptionsdk.internal.BouncyCastleConfiguration;
 import org.bouncycastle.crypto.Digest;
 import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.digests.SHA384Digest;
@@ -33,6 +33,7 @@ import org.bouncycastle.crypto.params.HKDFParameters;
 
 import com.amazonaws.encryptionsdk.internal.Constants;
 import com.amazonaws.encryptionsdk.model.CiphertextHeaders;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 /**
  * Describes the cryptographic algorithms available for use in this library.
@@ -103,15 +104,18 @@ public enum CryptoAlgorithm {
     private final int dataKeyLen_;
     private final boolean safeToCache_;
 
+    /**
+     * This block is used to ensure static blocks of BouncyCastleConfiguration are evaluated as a dependency of
+     * the CryptoAlgorithm class
+     */
     static {
         try {
-            Security.addProvider((Provider)
-                    Class.forName("org.bouncycastle.jce.provider.BouncyCastleProvider").newInstance());
-        } catch (final Throwable ex) {
-            // Swallow this error. We'll either succeed or fail later with reasonable
-            // stacktraces.
+            BouncyCastleConfiguration.class.newInstance();
+        } catch (Throwable e) {
+
         }
     }
+
 
     /*
      * Create a mapping between the CiphertextType object and its byte value representation. Make

--- a/src/main/java/com/amazonaws/encryptionsdk/CryptoAlgorithm.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/CryptoAlgorithm.java
@@ -109,13 +109,8 @@ public enum CryptoAlgorithm {
      * the CryptoAlgorithm class
      */
     static {
-        try {
-            BouncyCastleConfiguration.class.newInstance();
-        } catch (Throwable e) {
-
-        }
+        BouncyCastleConfiguration.init();
     }
-
 
     /*
      * Create a mapping between the CiphertextType object and its byte value representation. Make

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/BouncyCastleConfiguration.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/BouncyCastleConfiguration.java
@@ -5,7 +5,9 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import java.security.Security;
 
 /**
- * This API is internal and subject to change
+ * This API is internal and subject to change. It is used to add BouncyCastleProvider to the
+ * java.security.Provider list, and to provide a static reference to BouncyCastleProvider for internal
+ * classes.
  */
 public class BouncyCastleConfiguration {
     static final BouncyCastleProvider INTERNAL_BOUNCY_CASTLE_PROVIDER;
@@ -21,4 +23,15 @@ public class BouncyCastleConfiguration {
         }
         INTERNAL_BOUNCY_CASTLE_PROVIDER = bouncyCastleProvider;
     }
+
+    /**
+     * Prevent instantiation
+     */
+    private BouncyCastleConfiguration() {
+    }
+
+    /**
+     * No-op used to force class loading on first call, which will cause the static blocks to be executed
+     */
+    public static void init() {}
 }

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/BouncyCastleConfiguration.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/BouncyCastleConfiguration.java
@@ -1,0 +1,24 @@
+package com.amazonaws.encryptionsdk.internal;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import java.security.Security;
+
+/**
+ * This API is internal and subject to change
+ */
+public class BouncyCastleConfiguration {
+    static final BouncyCastleProvider INTERNAL_BOUNCY_CASTLE_PROVIDER;
+    static {
+        BouncyCastleProvider bouncyCastleProvider;
+        try {
+            bouncyCastleProvider = new BouncyCastleProvider();
+            Security.addProvider(bouncyCastleProvider);
+        } catch (final Throwable ex) {
+            bouncyCastleProvider = null;
+            // Swallow this error. We'll either succeed or fail later with reasonable
+            // stacktraces.
+        }
+        INTERNAL_BOUNCY_CASTLE_PROVIDER = bouncyCastleProvider;
+    }
+}

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
@@ -24,6 +24,8 @@ import com.amazonaws.encryptionsdk.CryptoAlgorithm;
  * NOTE: This is not a stable API and may undergo breaking changes in the future.
  */
 public abstract class TrailingSignatureAlgorithm {
+    private static final BouncyCastleProvider BC_PROVIDER = new BouncyCastleProvider();
+
     private TrailingSignatureAlgorithm() {
         /* Do not allow arbitrary subclasses */
     }
@@ -84,7 +86,7 @@ public abstract class TrailingSignatureAlgorithm {
 
         @Override
         public KeyPair generateKey() throws GeneralSecurityException {
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDSA", "BC");
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDSA", BC_PROVIDER);
             keyGen.initialize(ecSpec, Utils.getSecureRandom());
 
             return keyGen.generateKeyPair();

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
@@ -18,13 +18,14 @@ import java.util.Base64;
 
 import com.amazonaws.encryptionsdk.CryptoAlgorithm;
 
+import static com.amazonaws.encryptionsdk.internal.BouncyCastleConfiguration.INTERNAL_BOUNCY_CASTLE_PROVIDER;
+
 /**
  * Provides a consistent interface across various trailing signature algorithms.
  *
  * NOTE: This is not a stable API and may undergo breaking changes in the future.
  */
 public abstract class TrailingSignatureAlgorithm {
-    private static final BouncyCastleProvider BC_PROVIDER = new BouncyCastleProvider();
 
     private TrailingSignatureAlgorithm() {
         /* Do not allow arbitrary subclasses */
@@ -86,7 +87,7 @@ public abstract class TrailingSignatureAlgorithm {
 
         @Override
         public KeyPair generateKey() throws GeneralSecurityException {
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDSA", BC_PROVIDER);
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDSA", INTERNAL_BOUNCY_CASTLE_PROVIDER);
             keyGen.initialize(ecSpec, Utils.getSecureRandom());
 
             return keyGen.generateKeyPair();


### PR DESCRIPTION
This avoids issues where a shaded version of BCProvider is installed in the
system JCE provider list, which can result in problems when we pass an
ECNamedCurveParameterSpec from a different shaded version of BC.

Fixes: #68

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
