### PR TITLE
Update parameter to disable doc linting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
                 <configuration>
                     <minmemory>128m</minmemory>
                     <maxmemory>1024m</maxmemory>
-                    <additionalparam>-Xdoclint:none</additionalparam>
+                    <doclint>none</doclint>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
In the upgrade to maven javadoc 3.0.0, the parameter to ignore doc linting
changed. This means that javadoc fails to build. This updates the parameter to
the correct one for disabling linting.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
