### PR TITLE
Update README to state that Java 8 or higher is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To use this SDK you must have:
 
 * **A Java 8 development environment**
 
-  If you do not have one, go to [Java SE Downloads](https://www.oracle.com/technetwork/java/javase/downloads/index.html) on the Oracle website, then download and install the Java SE Development Kit (JDK). Java 8 or higher is recommended.
+  If you do not have one, go to [Java SE Downloads](https://www.oracle.com/technetwork/java/javase/downloads/index.html) on the Oracle website, then download and install the Java SE Development Kit (JDK). Java 8 or higher is required.
 
   **Note:** If you use the Oracle JDK, you must also download and install the [Java Cryptography Extension (JCE) Unlimited Strength Jurisdiction Policy Files](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html).
 


### PR DESCRIPTION
Previously, it wasn't clear whether Java 8 was recommended or required. This
makes it clear that Java 8 is the minimum supported version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
