### PR TITLE
Remove explicit BC usage when not necessary

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/CryptoAlgorithm.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/CryptoAlgorithm.java
@@ -33,7 +33,6 @@ import org.bouncycastle.crypto.params.HKDFParameters;
 
 import com.amazonaws.encryptionsdk.internal.Constants;
 import com.amazonaws.encryptionsdk.model.CiphertextHeaders;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 
 /**
  * Describes the cryptographic algorithms available for use in this library.

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/DecryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/DecryptionHandler.java
@@ -472,8 +472,7 @@ public class DecryptionHandler<K extends MasterKey<K>> implements MessageCryptoH
 
             try {
                 trailingSig_ = Signature.getInstance(
-                        trailingSignatureAlgorithm.getHashAndSignAlgorithm(),
-                        "BC"
+                        trailingSignatureAlgorithm.getHashAndSignAlgorithm()
                 );
 
                 trailingSig_.initVerify(trailingPublicKey);

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/TrailingSignatureAlgorithm.java
@@ -77,7 +77,7 @@ public abstract class TrailingSignatureAlgorithm {
                     new ECDomainParameters(ecSpec.getCurve(), ecSpec.getG(), ecSpec.getN(), ecSpec.getH())
             );
 
-            return new BCECPublicKey("ECDSA", keyParams, ecSpec, BouncyCastleProvider.CONFIGURATION);
+            return new BCECPublicKey("EC", keyParams, ecSpec, BouncyCastleProvider.CONFIGURATION);
         }
 
         @Override
@@ -87,7 +87,8 @@ public abstract class TrailingSignatureAlgorithm {
 
         @Override
         public KeyPair generateKey() throws GeneralSecurityException {
-            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("ECDSA", INTERNAL_BOUNCY_CASTLE_PROVIDER);
+            // We use BouncyCastle for this so that we can easily serialize the compressed point.
+            KeyPairGenerator keyGen = KeyPairGenerator.getInstance("EC", INTERNAL_BOUNCY_CASTLE_PROVIDER);
             keyGen.initialize(ecSpec, Utils.getSecureRandom());
 
             return keyGen.generateKeyPair();

--- a/src/test/java/com/amazonaws/encryptionsdk/DefaultCryptoMaterialsManagerTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/DefaultCryptoMaterialsManagerTest.java
@@ -257,7 +257,7 @@ public class DefaultCryptoMaterialsManagerTest {
                 assertNull(decryptMaterials.getTrailingSignatureKey());
             } else {
                 Signature sig = Signature.getInstance(
-                        TrailingSignatureAlgorithm.forCryptoAlgorithm(algorithm).getHashAndSignAlgorithm(), "BC"
+                        TrailingSignatureAlgorithm.forCryptoAlgorithm(algorithm).getHashAndSignAlgorithm()
                 );
 
                 sig.initSign(encryptMaterials.getTrailingSignatureKey());

--- a/src/test/java/com/amazonaws/encryptionsdk/jce/KeyStoreProviderTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/jce/KeyStoreProviderTest.java
@@ -58,8 +58,7 @@ public class KeyStoreProviderTest {
 
     static {
         try {
-            Security.addProvider(new BouncyCastleProvider());
-            KG = KeyPairGenerator.getInstance("RSA", "BC");
+            KG = KeyPairGenerator.getInstance("RSA");
             KG.initialize(2048);
         } catch (Exception ex) {
             throw new RuntimeException(ex);


### PR DESCRIPTION
This makes it so that we don't explicitly use BouncyCastle for crypto except when necessary. Exceptions include:
* KeyGeneration (for easy serialization of compressed points)
* RSA-OAEP (as the default java implementation is non-standard)

I have run multiple tests locally including verifying that installing custom providers at high priority still work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
