### PR TITLE
Fix broken javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
                     <minmemory>128m</minmemory>
                     <maxmemory>1024m</maxmemory>
                     <doclint>none</doclint>
+                    <source>8</source>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/com/amazonaws/encryptionsdk/MasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/MasterKeyProvider.java
@@ -61,7 +61,7 @@ public abstract class MasterKeyProvider<K extends MasterKey<K>> {
      * @param keyId
      * @return
      * @throws UnsupportedProviderException
-     *             if this object cannot return {@link MasterKeys} associated with the given
+     *             if this object cannot return {@link MasterKey}s associated with the given
      *             provider
      * @throws NoSuchMasterKeyException
      *             if this object cannot find (and thus construct) the {@link MasterKey} associated

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/CryptoHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/CryptoHandler.java
@@ -54,7 +54,7 @@ public interface CryptoHandler {
     /**
      * Return the size of the output buffer required for a
      * {@link #processBytes(byte[], int, int, byte[], int)} plus a {@link #doFinal(byte[], int)}
-     * call with an input of {@code inLen) bytes.
+     * call with an input of {@code inLen} bytes.
      * 
      * <p>
      * Note this method is allowed to return an estimation of the output size that is <i>greater</i>

--- a/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
@@ -105,8 +105,8 @@ public class CiphertextHeaders {
      * @param encryptionContext
      *            the bytes containing the encryption context to set in the
      *            header.
-     * @param keyBlob
-     *            the keyBlob object containing the key provider id, key
+     * @param keyBlobs
+     *            list of keyBlobs containing the key provider id, key
      *            provider info, and encrypted data key to encode in the header.
      * @param contentType
      *            the content type to set in the header.


### PR DESCRIPTION
In addition to some bad JavaDoc comments this informs the JavaDoc plugin
of our source version to avoid other errors.

Manually ran `mvn clean javadoc:javadoc` and saw that it now completes successfully (and it didn't before).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
