### PR TITLE
Version 1.4.1 uses ByteBuffers in a backwards compatible way.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.1 -- 2019-05-10
+
+### Patches
+* Cast ByteBuffer to Buffer prior to using some methods so that it works properly in Java 8.
+
 ## 1.4.0 -- 2019-05-10
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can get the latest release from Maven:
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-encryption-sdk-java</artifactId>
-  <version>1.4.0</version>
+  <version>1.4.1</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-encryption-sdk-java</artifactId>
-    <version>1.4.0</version>
+    <version>1.4.1</version>
     <packaging>jar</packaging>
 
     <name>aws-encryption-sdk-java</name>

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/EncryptionContextSerializer.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/EncryptionContextSerializer.java
@@ -113,7 +113,7 @@ public class EncryptionContextSerializer {
             }
 
             // get and return the bytes that have been serialized
-            result.flip();
+            Utils.flip(result);
             final byte[] encryptionContextBytes = new byte[result.limit()];
             result.get(encryptionContextBytes);
 
@@ -173,8 +173,8 @@ public class EncryptionContextSerializer {
                 }
 
                 final ByteBuffer keyBytes = encryptionContextBytes.slice();
-                keyBytes.limit(keyLen);
-                encryptionContextBytes.position(encryptionContextBytes.position() + keyLen);
+                Utils.limit(keyBytes, keyLen);
+                Utils.position(encryptionContextBytes, encryptionContextBytes.position() + keyLen);
 
                 final int valueLen = encryptionContextBytes.getShort();
                 if (valueLen <= 0 || valueLen > Short.MAX_VALUE) {
@@ -184,8 +184,8 @@ public class EncryptionContextSerializer {
 
                 // retrieve value
                 final ByteBuffer valueBytes = encryptionContextBytes.slice();
-                valueBytes.limit(valueLen);
-                encryptionContextBytes.position(encryptionContextBytes.position() + valueLen);
+                Utils.limit(valueBytes, valueLen);
+                Utils.position(encryptionContextBytes, encryptionContextBytes.position() + valueLen);
 
                 final CharBuffer keyChars = decoder.decode(keyBytes);
                 final CharBuffer valueChars = decoder.decode(valueBytes);

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/FrameEncryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/FrameEncryptionHandler.java
@@ -359,7 +359,7 @@ class FrameEncryptionHandler implements CryptoHandler {
         // We technically only allocate the low 32 bits for the frame number, and the other bits are defined to be
         // zero. However, since MAX_FRAME_NUMBER is 2^32-1, the high-order four bytes of the long will be zero, so the
         // big-endian representation will also have zeros in that position.
-        buf.position(buf.limit() - Long.BYTES);
+        Utils.position(buf, buf.limit() - Long.BYTES);
         buf.putLong(frameNumber_);
 
         return nonce;

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/Utils.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/Utils.java
@@ -249,7 +249,7 @@ public final class Utils {
         return buff;
     }
 
-        /**
+    /**
      * Equivalent to calling {@link ByteBuffer#limit(int)} but in a manner which is
      * safe when compiled on Java 9 or newer but used on Java 8 or older.
      */

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/Utils.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/Utils.java
@@ -14,6 +14,7 @@
 package com.amazonaws.encryptionsdk.internal;
 
 import java.io.Serializable;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
@@ -219,5 +220,41 @@ public final class Utils {
 
     static IllegalArgumentException cannotBeNegative(String field) {
         return new IllegalArgumentException(field + " cannot be negative");
+    }
+
+    /**
+     * Equivalent to calling {@link ByteBuffer#flip()} but in a manner which is
+     * safe when compiled on Java 9 or newer but used on Java 8 or older.
+     */
+    public static ByteBuffer flip(final ByteBuffer buff) {
+        ((Buffer) buff).flip();
+        return buff;
+    }
+
+    /**
+     * Equivalent to calling {@link ByteBuffer#clear()} but in a manner which is
+     * safe when compiled on Java 9 or newer but used on Java 8 or older.
+     */
+    public static ByteBuffer clear(final ByteBuffer buff) {
+        ((Buffer) buff).clear();
+        return buff;
+    }
+
+    /**
+     * Equivalent to calling {@link ByteBuffer#position(int)} but in a manner which is
+     * safe when compiled on Java 9 or newer but used on Java 8 or older.
+     */
+    public static ByteBuffer position(final ByteBuffer buff, final int newPosition) {
+        ((Buffer) buff).position(newPosition);
+        return buff;
+    }
+
+        /**
+     * Equivalent to calling {@link ByteBuffer#limit(int)} but in a manner which is
+     * safe when compiled on Java 9 or newer but used on Java 8 or older.
+     */
+    public static ByteBuffer limit(final ByteBuffer buff, final int newLimit) {
+        ((Buffer) buff).limit(newLimit);
+        return buff;
     }
 }

--- a/src/test/java/com/amazonaws/encryptionsdk/internal/FrameEncryptionHandlerVeryLongTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/internal/FrameEncryptionHandlerVeryLongTest.java
@@ -38,7 +38,7 @@ public class FrameEncryptionHandlerVeryLongTest {
         long lastIndex = 1; // starting index for the test
         long lastTS = System.nanoTime();
         for (long i = lastIndex; i <= Constants.MAX_FRAME_NUMBER; i++) {
-            expectedNonce.clear();
+            Utils.clear(expectedNonce);
             expectedNonce.order(ByteOrder.BIG_ENDIAN);
             expectedNonce.putInt(0);
             expectedNonce.putLong(i);


### PR DESCRIPTION
Java 9 introduced a change in ByteBuffers causing some methods to fail
when compiled with Java 9 (or newer) but executed on Java 8 (or older)
regardless of compatability levels applied.
See https://github.com/mongodb/mongo-java-driver/commit/21c91bd364d38489e0bbe2e390efdb3746ee3fff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
