### PR TITLE
Remove use of BouncyCastle from JceMasterKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 1.6.1 -- Unreleased
 ### Maintenance
-* Add support for standard test vectors via `testVectorZip` system property. 
+* Add support for standard test vectors via `testVectorZip` system property.
+* No longer require use of BouncyCastle with RSA `JceMasterKey`s
 
 ## 1.6.0 -- 2019-05-31
 


### PR DESCRIPTION
*Issue #, if available:* #41 

*Description of changes:*

Removes explicit use of BouncyCastle from the `JceMasterKey`. The concern and complexity here is that the default Java provider implements RSA-OAEP in an incompatible way. By using `OAEPParameterSpec` explicitly, we can work around the incompatibility in all cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

