### PR TITLE
fix: The final frame can not be larger than the Frame Length

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
@@ -119,6 +119,11 @@ class FrameDecryptionHandler implements CryptoHandler {
             if (currentFrameHeaders_ == null) {
                 currentFrameHeaders_ = new CipherFrameHeaders();
                 currentFrameHeaders_.setNonceLength(nonceLen_);
+                if (frameSize_ == 0) {
+                    // if frame size in ciphertext headers is 0, the frame size
+                    // will need to be parsed in individual frame headers.
+                    currentFrameHeaders_.includeFrameSize(true);
+                }
             }
 
             totalParsedBytes += currentFrameHeaders_.deserialize(bytesToParse, totalParsedBytes);
@@ -130,7 +135,7 @@ class FrameDecryptionHandler implements CryptoHandler {
                     protectedContentLen = currentFrameHeaders_.getFrameContentLength();
 
                     // The final frame should not be able to exceed the frameLength
-                    if(protectedContentLen > frameSize_) {
+                    if(frameSize_ > 0 && protectedContentLen > frameSize_) {
                         throw new BadCiphertextException("Final frame length exceeds frame length.");
                     }
                 } else {

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
@@ -135,7 +135,7 @@ class FrameDecryptionHandler implements CryptoHandler {
                     protectedContentLen = currentFrameHeaders_.getFrameContentLength();
 
                     // The final frame should not be able to exceed the frameLength
-                    if(frameSize_ > 0 && protectedContentLen > frameSize_) {
+                    if (frameSize_ > 0 && protectedContentLen > frameSize_) {
                         throw new BadCiphertextException("Final frame length exceeds frame length.");
                     }
                 } else {

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
@@ -133,6 +133,11 @@ class FrameDecryptionHandler implements CryptoHandler {
                 int protectedContentLen = -1;
                 if (currentFrameHeaders_.isFinalFrame()) {
                     protectedContentLen = currentFrameHeaders_.getFrameContentLength();
+
+                    // The final frame should not be able to exceed the frameLength
+                    if(frameSize_ > 0 && protectedContentLen > frameSize_) {
+                        throw new BadCiphertextException("Final frame length exceeds frame length.");
+                    }
                 } else {
                     protectedContentLen = frameSize_;
                 }

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
@@ -119,11 +119,6 @@ class FrameDecryptionHandler implements CryptoHandler {
             if (currentFrameHeaders_ == null) {
                 currentFrameHeaders_ = new CipherFrameHeaders();
                 currentFrameHeaders_.setNonceLength(nonceLen_);
-                if (frameSize_ == 0) {
-                    // if frame size in ciphertext headers is 0, the frame size
-                    // will need to be parsed in individual frame headers.
-                    currentFrameHeaders_.includeFrameSize(true);
-                }
             }
 
             totalParsedBytes += currentFrameHeaders_.deserialize(bytesToParse, totalParsedBytes);
@@ -135,7 +130,7 @@ class FrameDecryptionHandler implements CryptoHandler {
                     protectedContentLen = currentFrameHeaders_.getFrameContentLength();
 
                     // The final frame should not be able to exceed the frameLength
-                    if(frameSize_ > 0 && protectedContentLen > frameSize_) {
+                    if(protectedContentLen > frameSize_) {
                         throw new BadCiphertextException("Final frame length exceeds frame length.");
                     }
                 } else {

--- a/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
@@ -143,6 +143,10 @@ public class CiphertextHeaders {
         messageId_ = new byte[Constants.MESSAGE_ID_LEN];
         RND.nextBytes(messageId_);
 
+        if(contentType == ContentType.FRAME && frameSize <= 0) {
+            throw new BadCiphertextException("Framed data requires a positive frame length");
+        }
+
         frameLength_ = frameSize;
 
         // Completed by construction
@@ -628,6 +632,10 @@ public class CiphertextHeaders {
 
             if (headerTag_ == null) {
                 parsedBytes += parseHeaderTag(b, off + parsedBytes);
+            }
+
+            if(frameLength_ <= 0 && ContentType.deserialize(contentTypeVal_) == ContentType.FRAME) {
+                throw new BadCiphertextException("Framed data requires a positive frame length");
             }
 
             isComplete_ = true;

--- a/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
@@ -143,10 +143,6 @@ public class CiphertextHeaders {
         messageId_ = new byte[Constants.MESSAGE_ID_LEN];
         RND.nextBytes(messageId_);
 
-        if(contentType == ContentType.FRAME && frameSize <= 0) {
-            throw new BadCiphertextException("Framed data requires a positive frame length");
-        }
-
         frameLength_ = frameSize;
 
         // Completed by construction
@@ -632,10 +628,6 @@ public class CiphertextHeaders {
 
             if (headerTag_ == null) {
                 parsedBytes += parseHeaderTag(b, off + parsedBytes);
-            }
-
-            if(frameLength_ <= 0 && ContentType.deserialize(contentTypeVal_) == ContentType.FRAME) {
-                throw new BadCiphertextException("Framed data requires a positive frame length");
             }
 
             isComplete_ = true;

--- a/src/test/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandlerTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandlerTest.java
@@ -15,11 +15,14 @@ package com.amazonaws.encryptionsdk.internal;
 
 import static org.junit.Assert.assertTrue;
 
+import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 
+import com.amazonaws.encryptionsdk.TestUtils;
+import com.amazonaws.encryptionsdk.exception.BadCiphertextException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -71,5 +74,19 @@ public class FrameDecryptionHandlerTest {
 
         frameDecryptionHandler_.processBytes(in, 0, in.length, out, 0);
         frameDecryptionHandler_.processBytes(in, 0, Integer.MAX_VALUE, out, 0);
+    }
+
+    @Test(expected = BadCiphertextException.class)
+    public void finalFrameLengthTooLarge() {
+
+        final ByteBuffer byteBuffer = ByteBuffer.allocate(25);
+        byteBuffer.put(TestUtils.unsignedBytesToSignedBytes(
+                new int[] {255, 255, 255, 255, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1}));
+        byteBuffer.putInt(AwsCrypto.getDefaultFrameSize() + 1);
+
+        final byte[] in = byteBuffer.array();
+        final byte[] out = new byte[in.length];
+
+        frameDecryptionHandler_.processBytes(in, 0, in.length, out, 0);
     }
 }

--- a/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
@@ -431,8 +431,8 @@ public class CiphertextHeadersTest {
 
         readUptoNonceLen(headerBuff);
 
-        // set content type to an invalid value
-        headerBuff.putInt(-1);
+        // set frame type to an invalid value for framed data
+        headerBuff.putInt(0);
 
         final CiphertextHeaders reconstructedHeaders = new CiphertextHeaders();
         reconstructedHeaders.deserialize(headerBuff.array(), 0);

--- a/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
@@ -431,7 +431,7 @@ public class CiphertextHeadersTest {
 
         readUptoNonceLen(headerBuff);
 
-        // set frame type to an invalid value
+        // set content type to an invalid value
         headerBuff.putInt(-1);
 
         final CiphertextHeaders reconstructedHeaders = new CiphertextHeaders();

--- a/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
@@ -431,8 +431,8 @@ public class CiphertextHeadersTest {
 
         readUptoNonceLen(headerBuff);
 
-        // set frame type to an invalid value for framed data
-        headerBuff.putInt(0);
+        // set frame type to an invalid value
+        headerBuff.putInt(-1);
 
         final CiphertextHeaders reconstructedHeaders = new CiphertextHeaders();
         reconstructedHeaders.deserialize(headerBuff.array(), 0);


### PR DESCRIPTION
Add validation to ensure the length of the final frame in the final frame header does not exceed the frame size specified in the message header.

See https://github.com/aws/aws-encryption-sdk-javascript/pull/281

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.