### PR TITLE
Update BouncyCastle to 1.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ calls to `AwsCrypto.encrypt(EncryptRequest)` and `AwsCrypto.decrypt(DecryptReque
 * Update AWS Java SDK version from 1.11.561 to 1.11.677. [PR #147](https://github.com/aws/aws-encryption-sdk-java/pull/147)
 * Upgrade JUnit from 4.12 to 5.5.2 [PR #151](https://github.com/aws/aws-encryption-sdk-java/pull/151)
 * Upgrade Mockito from 2.28.1 to 3.1.0 [PR #142](https://github.com/aws/aws-encryption-sdk-java/pull/142)
+* Upgrade Bouncy Castle from 1.61 to 1.65 [PR #179](https://github.com/aws/aws-encryption-sdk-java/pull/179)
 
 ### Documentation
 * Added new examples demonstrating how to use

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-ext-jdk15on</artifactId>
-            <version>1.61</version>
+            <version>1.65</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating Bouncy Castle to the latest version (1.65)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

