### PR TITLE
Throw a more useful exception when trying to use the RawRsaKeyring to encrypt without a public key

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/keyrings/RawRsaKeyring.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/keyrings/RawRsaKeyring.java
@@ -14,8 +14,10 @@
 package com.amazonaws.encryptionsdk.keyrings;
 
 import com.amazonaws.encryptionsdk.EncryptedDataKey;
+import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.internal.JceKeyCipher;
 import com.amazonaws.encryptionsdk.keyrings.RawRsaKeyringBuilder.RsaPaddingScheme;
+import com.amazonaws.encryptionsdk.model.EncryptionMaterials;
 
 import java.security.PrivateKey;
 import java.security.PublicKey;
@@ -29,8 +31,20 @@ import java.util.Arrays;
  */
 class RawRsaKeyring extends RawKeyring {
 
+    private final boolean validToEncrypt;
+
     RawRsaKeyring(String keyNamespace, String keyName, PublicKey publicKey, PrivateKey privateKey, RsaPaddingScheme rsaPaddingScheme) {
         super(keyNamespace, keyName, JceKeyCipher.rsa(publicKey, privateKey, rsaPaddingScheme.getTransformation()));
+        validToEncrypt = publicKey != null;
+    }
+
+    @Override
+    public EncryptionMaterials onEncrypt(EncryptionMaterials encryptionMaterials) {
+        if(!validToEncrypt) {
+            throw new AwsCryptoException("A public key is required to encrypt");
+        }
+
+        return super.onEncrypt(encryptionMaterials);
     }
 
     @Override

--- a/src/test/java/com/amazonaws/encryptionsdk/keyrings/RawRsaKeyringTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/keyrings/RawRsaKeyringTest.java
@@ -153,4 +153,30 @@ class RawRsaKeyringTest {
         assertThrows(AwsCryptoException.class, () -> noPublicKey.onEncrypt(encryptionMaterials));
     }
 
+    @Test
+    void testDecryptWithNoPrivateKey() throws Exception {
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        final KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+        Keyring noPrivateKey = new RawRsaKeyring(KEYNAMESPACE, KEYNAME, keyPair.getPublic(), null, PADDING_SCHEME);
+
+        EncryptionMaterials encryptionMaterials = EncryptionMaterials.newBuilder()
+                .setAlgorithm(ALGORITHM)
+                .setCleartextDataKey(DATA_KEY)
+                .setEncryptionContext(ENCRYPTION_CONTEXT)
+                .build();
+
+        encryptionMaterials = noPrivateKey.onEncrypt(encryptionMaterials);
+
+        DecryptionMaterials decryptionMaterials = DecryptionMaterials.newBuilder()
+                .setAlgorithm(ALGORITHM)
+                .setEncryptionContext(ENCRYPTION_CONTEXT)
+                .build();
+
+        DecryptionMaterials resultDecryptionMaterials = noPrivateKey.onDecrypt(decryptionMaterials, encryptionMaterials.getEncryptedDataKeys());
+
+        assertEquals(decryptionMaterials, resultDecryptionMaterials);
+    }
+
 }

--- a/src/test/java/com/amazonaws/encryptionsdk/keyrings/RawRsaKeyringTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/keyrings/RawRsaKeyringTest.java
@@ -14,6 +14,7 @@
 package com.amazonaws.encryptionsdk.keyrings;
 
 import com.amazonaws.encryptionsdk.EncryptedDataKey;
+import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.keyrings.RawRsaKeyringBuilder.RsaPaddingScheme;
 import com.amazonaws.encryptionsdk.model.DecryptionMaterials;
 import com.amazonaws.encryptionsdk.model.EncryptionMaterials;
@@ -34,6 +35,7 @@ import static com.amazonaws.encryptionsdk.keyrings.RawKeyringTest.KEYNAMESPACE;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RawRsaKeyringTest {
@@ -132,6 +134,23 @@ class RawRsaKeyringTest {
         assertEquals(KEYNAMESPACE, decryptionMaterials.getKeyringTrace().getEntries().get(0).getKeyNamespace());
         assertEquals(1, decryptionMaterials.getKeyringTrace().getEntries().get(0).getFlags().size());
         assertTrue(decryptionMaterials.getKeyringTrace().getEntries().get(0).getFlags().contains(KeyringTraceFlag.DECRYPTED_DATA_KEY));
+    }
+
+    @Test
+    void testEncryptWithNoPublicKey() throws Exception {
+        final KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048);
+        final KeyPair keyPair = keyPairGenerator.generateKeyPair();
+
+        Keyring noPublicKey = new RawRsaKeyring(KEYNAMESPACE, KEYNAME, null, keyPair.getPrivate(), PADDING_SCHEME);
+
+        EncryptionMaterials encryptionMaterials = EncryptionMaterials.newBuilder()
+                .setAlgorithm(ALGORITHM)
+                .setCleartextDataKey(DATA_KEY)
+                .setEncryptionContext(ENCRYPTION_CONTEXT)
+                .build();
+
+        assertThrows(AwsCryptoException.class, () -> noPublicKey.onEncrypt(encryptionMaterials));
     }
 
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently we rely on the JCE Cipher class to throw an exception when a user tries to encrypt with the RawRsaKeyring but has not configured a public key. The exception message does not obviously indicate what is wrong, so this change will explicitly check for a missing public key before attempting encryption and throw a more useful exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

