### PR TITLE
docs: add links to custom AWS KMS client configuration examples in examples readme

### DIFF
--- a/src/examples/README.md
+++ b/src/examples/README.md
@@ -41,6 +41,10 @@ We start with AWS KMS examples, then show how to use other wrapping keys.
         * [with keyrings](./java/com/amazonaws/crypto/examples/keyring/awskms/DiscoveryDecryptWithPreferredRegions.java)
     * How to reproduce the behavior of an AWS KMS master key provider
         * [with keyrings](./java/com/amazonaws/crypto/examples/keyring/awskms/ActLikeAwsKmsMasterKeyProvider.java)
+    * How to use AWS KMS clients with custom configuration
+        * [with keyrings](./java/com/amazonaws/crypto/examples/keyring/awskms/CustomKmsClientConfig.java)
+    * How to use different AWS KMS client for different regions
+        * [with keyrings](./java/com/amazonaws/crypto/examples/keyring/awskms/CustomClientSupplier.java)
 * Using raw wrapping keys
     * How to use a raw AES wrapping key
         * [with keyrings](./java/com/amazonaws/crypto/examples/keyring/rawaes/RawAes.java)


### PR DESCRIPTION
*Description of changes:*

In going through to enumerate the examples for https://github.com/awslabs/aws-encryption-sdk-specification/issues/103, I realized that the client supplier examples were not linked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

