### PR TITLE
fix: validate entire ciphertext has been processed before returning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 1.6.2 -- unreleased
+## 1.6.2 -- 2020-05-26
 
 ### Patches
 * Validate final frame length does not exceed the frame size in the message header [PR #166](https://github.com/aws/aws-encryption-sdk-java/pull/166)
+* Validate entire ciphertext has been processed before returning [PR #191](https://github.com/aws/aws-encryption-sdk-java/pull/191)
 
 ### Maintenance
 * Update AWS Java SDK version from 1.11.561 to 1.11.704. [PR #186](https://github.com/aws/aws-encryption-sdk-java/pull/186)

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/BlockDecryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/BlockDecryptionHandler.java
@@ -13,15 +13,14 @@
 
 package com.amazonaws.encryptionsdk.internal;
 
-import java.util.Arrays;
-
-import javax.crypto.Cipher;
-import javax.crypto.SecretKey;
-
 import com.amazonaws.encryptionsdk.CryptoAlgorithm;
 import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.exception.BadCiphertextException;
 import com.amazonaws.encryptionsdk.model.CipherBlockHeaders;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import java.util.Arrays;
 
 /**
  * The block decryption handler is an implementation of CryptoHandler that
@@ -97,6 +96,11 @@ class BlockDecryptionHandler implements CryptoHandler {
     synchronized public ProcessingSummary processBytes(final byte[] in, final int off, final int len,
             final byte[] out,
             final int outOff) throws AwsCryptoException {
+
+        if (complete_) {
+            throw new AwsCryptoException("Ciphertext has already been processed.");
+        }
+
         final byte[] bytesToParse = new byte[unparsedBytes_.length + len];
         // If there were previously unparsed bytes, add them as the first
         // set of bytes to be parsed in this call.
@@ -166,6 +170,9 @@ class BlockDecryptionHandler implements CryptoHandler {
      */
     @Override
     synchronized public int doFinal(final byte[] out, final int outOff) throws BadCiphertextException {
+        if (!complete_) {
+            throw new BadCiphertextException("Unable to process entire ciphertext.");
+        }
         return 0;
     }
 

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/DecryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/DecryptionHandler.java
@@ -326,6 +326,10 @@ public class DecryptionHandler<K extends MasterKey<K>> implements MessageCryptoH
         } else {
             int result = contentCryptoHandler_.doFinal(out, outOff);
 
+            if (!ciphertextHeaders_.isComplete() || !contentCryptoHandler_.isComplete()) {
+                throw new BadCiphertextException("Unable to process entire ciphertext.");
+            }
+
             return result;
         }
     }

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandler.java
@@ -78,16 +78,16 @@ class FrameDecryptionHandler implements CryptoHandler {
      * 
      * @param in
      *            the input byte array.
-     * @param inOff
+     * @param off
      *            the offset into the in array where the data to be decrypted starts.
-     * @param inLen
+     * @param len
      *            the number of bytes to be decrypted.
      * @param out
      *            the output buffer the decrypted plaintext bytes go into.
      * @param outOff
      *            the offset into the output byte array the decrypted data starts at.
      * @return the number of bytes written to out and processed
-     * @throws InvalidCiphertextException
+     * @throws BadCiphertextException
      *             if frame number is invalid/out-of-order or if the bytes do not decrypt correctly.
      * @throws AwsCryptoException
      *             if the content type found in the headers is not of frame type.
@@ -96,6 +96,11 @@ class FrameDecryptionHandler implements CryptoHandler {
     public ProcessingSummary processBytes(final byte[] in, final int off, final int len, final byte[] out,
             final int outOff)
             throws BadCiphertextException, AwsCryptoException {
+
+        if (complete_) {
+            throw new AwsCryptoException("Ciphertext has already been processed.");
+        }
+
         final long totalBytesToParse = unparsedBytes_.length + (long) len;
         if (totalBytesToParse > Integer.MAX_VALUE) {
             throw new AwsCryptoException(
@@ -200,6 +205,10 @@ class FrameDecryptionHandler implements CryptoHandler {
      */
     @Override
     public int doFinal(final byte[] out, final int outOff) {
+        if (!complete_) {
+            throw new BadCiphertextException("Unable to process entire ciphertext.");
+        }
+
         return 0;
     }
 

--- a/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
@@ -106,6 +107,31 @@ public class AwsCryptoTest {
                     masterKeyProvider,
                     cipherText
                     ).getResult();
+            Assert.fail("Expected BadCiphertextException");
+        } catch (final BadCiphertextException ex) {
+            // Expected exception
+        }
+    }
+
+    private void doTruncatedEncryptDecrypt(final CryptoAlgorithm cryptoAlg, final int byteSize, final int frameSize) {
+        final byte[] plaintextBytes = new byte[byteSize];
+
+        final Map<String, String> encryptionContext = new HashMap<>(1);
+        encryptionContext.put("ENC1", "Encrypt-decrypt test with %d" + byteSize);
+
+        encryptionClient_.setEncryptionAlgorithm(cryptoAlg);
+        encryptionClient_.setEncryptionFrameSize(frameSize);
+
+        final byte[] cipherText = encryptionClient_.encryptData(
+                masterKeyProvider,
+                plaintextBytes,
+                encryptionContext).getResult();
+        final byte[] truncatedCipherText = Arrays.copyOf(cipherText, cipherText.length - 1);
+        try {
+            encryptionClient_.decryptData(
+                    masterKeyProvider,
+                    truncatedCipherText
+            ).getResult();
             Assert.fail("Expected BadCiphertextException");
         } catch (final BadCiphertextException ex) {
             // Expected exception
@@ -189,6 +215,31 @@ public class AwsCryptoTest {
 
                     if (byteSize >= 0) {
                         doTamperedEncryptDecrypt(cryptoAlg, byteSize, frameSize);
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void encryptDecryptWithTruncatedCiphertext() {
+        for (final CryptoAlgorithm cryptoAlg : EnumSet.allOf(CryptoAlgorithm.class)) {
+            final int[] frameSizeToTest = TestUtils.getFrameSizesToTest(cryptoAlg);
+
+            for (int i = 0; i < frameSizeToTest.length; i++) {
+                final int frameSize = frameSizeToTest[i];
+                int[] bytesToTest = { 0, 1, frameSize - 1, frameSize, frameSize + 1, (int) (frameSize * 1.5),
+                        frameSize * 2, 1000000 };
+
+                for (int j = 0; j < bytesToTest.length; j++) {
+                    final int byteSize = bytesToTest[j];
+
+                    if (byteSize > 500_000) {
+                        continue;
+                    }
+
+                    if (byteSize >= 0) {
+                        doTruncatedEncryptDecrypt(cryptoAlg, byteSize, frameSize);
                     }
                 }
             }

--- a/src/test/java/com/amazonaws/encryptionsdk/internal/DecryptionHandlerTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/internal/DecryptionHandlerTest.java
@@ -16,6 +16,7 @@ package com.amazonaws.encryptionsdk.internal;
 import java.util.Collections;
 import java.util.Map;
 
+import com.amazonaws.encryptionsdk.model.CiphertextHeaders;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -139,5 +140,19 @@ public class DecryptionHandlerTest {
         final byte[] in = new byte[1];
         final byte[] out = new byte[1];
         decryptionHandler.processBytes(in, -1, in.length, out, 0);
+    }
+
+    @Test(expected = BadCiphertextException.class)
+    public void incompleteCiphertext() {
+        byte[] ciphertext = getTestHeaders();
+
+        CiphertextHeaders h = new CiphertextHeaders();
+        h.deserialize(ciphertext, 0);
+
+        final DecryptionHandler<StaticMasterKey> decryptionHandler = DecryptionHandler.create(masterKeyProvider_);
+        final byte[] out = new byte[1];
+
+        decryptionHandler.processBytes(ciphertext, 0, ciphertext.length - 1, out, 0);
+        decryptionHandler.doFinal(out, 0);
     }
 }

--- a/src/test/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandlerTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/internal/FrameDecryptionHandlerTest.java
@@ -89,4 +89,30 @@ public class FrameDecryptionHandlerTest {
 
         frameDecryptionHandler_.processBytes(in, 0, in.length, out, 0);
     }
+
+    @Test(expected = BadCiphertextException.class)
+    public void doFinalCalledWhileNotComplete() {
+        frameDecryptionHandler_.doFinal(new byte[1], 0);
+    }
+
+    @Test(expected = AwsCryptoException.class)
+    public void processBytesCalledWhileComplete() {
+        final FrameEncryptionHandler frameEncryptionHandler = new FrameEncryptionHandler(
+                dataKey_,
+                nonceLen_,
+                cryptoAlgorithm_,
+                messageId_,
+                frameSize_);
+        final byte[] in = new byte[0];
+        final int outLen = frameEncryptionHandler.estimateOutputSize(in.length);
+        final byte[] out = new byte[outLen];
+
+        frameEncryptionHandler.processBytes(in, 0, in.length, out, 0);
+        frameEncryptionHandler.doFinal(out, 0);
+
+        final byte[] decryptedOut = new byte[outLen];
+
+        frameDecryptionHandler_.processBytes(out, 0, out.length, decryptedOut, 0);
+        frameDecryptionHandler_.processBytes(out, 0, out.length, decryptedOut, 0);
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Validate that the entire ciphertext has been processed before returning

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

