### PR TITLE
pinentry-mode is not supported in older versions of gpg

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -165,12 +165,6 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
-                                <configuration>
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

pinentry-mode was introduced in gpg 2.1.12. Older versions of gpg are still deployed, so this change will allow hosts with those older versions to deploy to Maven.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

