### PR TITLE
feat: Add maxBodySize and maxHeaderSize params to decrypt streams

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -884,7 +884,7 @@ public class AwsCrypto {
      * @see javax.crypto.CipherOutputStream
      */
     public AwsCryptoOutputStream createDecryptingOutputStream(final CreateDecryptingOutputStreamRequest request) {
-        final MessageCryptoHandler cryptoHandler = DecryptionHandler.create(request.cryptoMaterialsManager());
+        final MessageCryptoHandler cryptoHandler = DecryptionHandler.create(request.cryptoMaterialsManager(), request.maxBodySize(), request.maxHeaderSize());
         return new AwsCryptoOutputStream(request.outputStream(), cryptoHandler);
     }
 
@@ -932,7 +932,7 @@ public class AwsCrypto {
     public AwsCryptoInputStream createDecryptingInputStream(final CreateDecryptingInputStreamRequest request) {
         requireNonNull(request, "request is required");
 
-        final MessageCryptoHandler cryptoHandler = DecryptionHandler.create(request.cryptoMaterialsManager());
+        final MessageCryptoHandler cryptoHandler = DecryptionHandler.create(request.cryptoMaterialsManager(), request.maxBodySize(), request.maxHeaderSize());
         return new AwsCryptoInputStream(request.inputStream(), cryptoHandler);
     }
 

--- a/src/main/java/com/amazonaws/encryptionsdk/CreateDecryptingInputStreamRequest.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/CreateDecryptingInputStreamRequest.java
@@ -20,12 +20,22 @@ import static java.util.Objects.requireNonNull;
 public class CreateDecryptingInputStreamRequest extends AwsCryptoRequest {
 
     private final InputStream inputStream;
+    private final Integer maxBodySize;
+    private final Integer maxHeaderSize;
 
     private CreateDecryptingInputStreamRequest(Builder builder) {
         super(builder);
 
         requireNonNull(builder.inputStream, "inputStream is required");
+        if (builder.maxBodySize != null && builder.maxBodySize < 0) {
+            throw new IllegalArgumentException("maxBodySize must be null or non-negative.");
+        }
+        if (builder.maxHeaderSize != null && builder.maxHeaderSize < 0) {
+            throw new IllegalArgumentException("maxHeaderSize must be null or positive.");
+        }
         this.inputStream = builder.inputStream;
+        this.maxBodySize = builder.maxBodySize;
+        this.maxHeaderSize = builder.maxHeaderSize;
     }
 
     /**
@@ -36,6 +46,15 @@ public class CreateDecryptingInputStreamRequest extends AwsCryptoRequest {
     public InputStream inputStream() {
         return this.inputStream;
     }
+
+    public Integer maxBodySize() {
+        return maxBodySize;
+    }
+
+    public Integer maxHeaderSize() {
+        return maxHeaderSize;
+    }
+
 
     /**
      * A builder for constructing an instance of {@code CreateDecryptingInputStreamRequest}.
@@ -49,6 +68,8 @@ public class CreateDecryptingInputStreamRequest extends AwsCryptoRequest {
     public static class Builder extends AwsCryptoRequest.Builder<Builder> {
 
         private InputStream inputStream;
+        private Integer maxBodySize;
+        private Integer maxHeaderSize;
 
         /**
          * Sets the {@link InputStream}
@@ -59,6 +80,39 @@ public class CreateDecryptingInputStreamRequest extends AwsCryptoRequest {
         public Builder inputStream(InputStream inputStream) {
             requireNonNull(inputStream, "inputStream is required");
             this.inputStream = inputStream;
+            return this;
+        }
+
+        /**
+         * Sets the maxBodySize
+         *
+         * @param maxBodySize The maximum length of encrypted content that is
+         *   allowed to be decrypted at once. Decryption will fail on any encrypted message
+         *   that requires performing one decryption operation on a length greater
+         *   than this value.
+         * @return The Builder, for method chaining
+         */
+        public Builder maxBodySize(Integer maxBodySize) {
+            if (maxBodySize < 0) {
+                throw new IllegalArgumentException("maxBodySize must be null or non-negative");
+            }
+            this.maxBodySize = maxBodySize;
+            return this;
+        }
+
+        /**
+         * Sets the maxHeaderSize
+         *
+         * @param maxHeaderSize The maximum length of message header that is
+         *   allowed to be deserialized. Decryption will fail on any encrypted message
+         *   with a message header length greater than this value.
+         * @return The Builder, for method chaining
+         */
+        public Builder maxHeaderSize(Integer maxHeaderSize) {
+            if (maxHeaderSize < 0) {
+                throw new IllegalArgumentException("maxHeaderSize must be null or positive");
+            }
+            this.maxHeaderSize = maxHeaderSize;
             return this;
         }
 

--- a/src/main/java/com/amazonaws/encryptionsdk/CreateDecryptingOutputStreamRequest.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/CreateDecryptingOutputStreamRequest.java
@@ -20,12 +20,22 @@ import static java.util.Objects.requireNonNull;
 public class CreateDecryptingOutputStreamRequest extends AwsCryptoRequest {
 
     private final OutputStream outputStream;
+    private final Integer maxBodySize;
+    private final Integer maxHeaderSize;
 
     private CreateDecryptingOutputStreamRequest(Builder builder) {
         super(builder);
 
         requireNonNull(builder.outputStream, "outputStream is required");
+        if (builder.maxBodySize != null && builder.maxBodySize < 0) {
+            throw new IllegalArgumentException("maxBodySize must be null or non-negative.");
+        }
+        if (builder.maxHeaderSize != null && builder.maxHeaderSize < 0) {
+            throw new IllegalArgumentException("maxHeaderSize must be null or positive.");
+        }
         this.outputStream = builder.outputStream;
+        this.maxBodySize = builder.maxBodySize;
+        this.maxHeaderSize = builder.maxHeaderSize;
     }
 
     /**
@@ -35,6 +45,14 @@ public class CreateDecryptingOutputStreamRequest extends AwsCryptoRequest {
      */
     public OutputStream outputStream() {
         return this.outputStream;
+    }
+
+    public Integer maxBodySize() {
+        return maxBodySize;
+    }
+
+    public Integer maxHeaderSize() {
+        return maxHeaderSize;
     }
 
     /**
@@ -49,6 +67,8 @@ public class CreateDecryptingOutputStreamRequest extends AwsCryptoRequest {
     public static class Builder extends AwsCryptoRequest.Builder<Builder> {
 
         private OutputStream outputStream;
+        private Integer maxBodySize;
+        private Integer maxHeaderSize;
 
         /**
          * Sets the {@link OutputStream}
@@ -59,6 +79,39 @@ public class CreateDecryptingOutputStreamRequest extends AwsCryptoRequest {
         public Builder outputStream(OutputStream outputStream) {
             requireNonNull(outputStream, "outputStream is required");
             this.outputStream = outputStream;
+            return this;
+        }
+
+        /**
+         * Sets the maxBodySize
+         *
+         * @param maxBodySize The maximum length of encrypted content that is
+         *   allowed to be decrypted at once. Decryption will fail on any encrypted message
+         *   that requires performing one decryption operation on a length greater
+         *   than this value.
+         * @return The Builder, for method chaining
+         */
+        public Builder maxBodySize(Integer maxBodySize) {
+            if (maxBodySize < 0) {
+                throw new IllegalArgumentException("maxBodySize must be null or non-negative");
+            }
+            this.maxBodySize = maxBodySize;
+            return this;
+        }
+
+        /**
+         * Sets the maxHeaderSize
+         *
+         * @param maxHeaderSize The maximum length of message header that is
+         *   allowed to be deserialized. Decryption will fail on any encrypted message
+         *   with a message header length greater than this value.
+         * @return The Builder, for method chaining
+         */
+        public Builder maxHeaderSize(Integer maxHeaderSize) {
+            if (maxHeaderSize < 0) {
+                throw new IllegalArgumentException("maxHeaderSize must be null or positive");
+            }
+            this.maxHeaderSize = maxHeaderSize;
             return this;
         }
 

--- a/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
@@ -867,6 +867,50 @@ public class AwsCryptoTest {
     }
 
     @Test
+    public void setInvalidMaxBodySize() throws IOException {
+        CryptoMaterialsManager cmm = new DefaultCryptoMaterialsManager(masterKeyProvider);
+        InputStream is = new ByteArrayInputStream(new byte[0]);
+        OutputStream os = new ByteArrayOutputStream();
+        assertThrows(IllegalArgumentException.class,
+                () -> encryptionClient_.createDecryptingInputStream(CreateDecryptingInputStreamRequest.builder()
+                        .cryptoMaterialsManager(cmm)
+                        .inputStream(is)
+                        .maxBodySize(-1).build()));
+        assertThrows(IllegalArgumentException.class,
+                () -> encryptionClient_.createDecryptingOutputStream(CreateDecryptingOutputStreamRequest.builder()
+                        .cryptoMaterialsManager(cmm)
+                        .outputStream(os)
+                        .maxBodySize(-1).build()));
+    }
+
+    @Test
+    public void setInvalidMaxHeaderSize() throws IOException {
+        CryptoMaterialsManager cmm = new DefaultCryptoMaterialsManager(masterKeyProvider);
+        InputStream is = new ByteArrayInputStream(new byte[0]);
+        OutputStream os = new ByteArrayOutputStream();
+        assertThrows(IllegalArgumentException.class,
+                () -> encryptionClient_.createDecryptingInputStream(CreateDecryptingInputStreamRequest.builder()
+                        .cryptoMaterialsManager(cmm)
+                        .inputStream(is)
+                        .maxHeaderSize(-1).build()));
+        assertThrows(IllegalArgumentException.class,
+                () -> encryptionClient_.createDecryptingInputStream(CreateDecryptingInputStreamRequest.builder()
+                        .cryptoMaterialsManager(cmm)
+                        .inputStream(is)
+                        .maxHeaderSize(0).build()));
+        assertThrows(IllegalArgumentException.class,
+                () -> encryptionClient_.createDecryptingOutputStream(CreateDecryptingOutputStreamRequest.builder()
+                        .cryptoMaterialsManager(cmm)
+                        .outputStream(os)
+                        .maxHeaderSize(-1).build()));
+        assertThrows(IllegalArgumentException.class,
+                () -> encryptionClient_.createDecryptingOutputStream(CreateDecryptingOutputStreamRequest.builder()
+                        .cryptoMaterialsManager(cmm)
+                        .outputStream(os)
+                        .maxHeaderSize(0).build()));
+    }
+
+    @Test
     public void setCryptoAlgorithm() throws IOException {
         final CryptoAlgorithm setCryptoAlgorithm = CryptoAlgorithm.ALG_AES_192_GCM_IV12_TAG16_NO_KDF;
         encryptionClient_.setEncryptionAlgorithm(setCryptoAlgorithm);

--- a/src/test/java/com/amazonaws/encryptionsdk/internal/DecryptionHandlerTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/internal/DecryptionHandlerTest.java
@@ -169,4 +169,20 @@ public class DecryptionHandlerTest {
         decryptionHandler.processBytes(getTestHeaders(), 0, testHeaders.length, out, 0);
         assertEquals(0, decryptionHandler.getMasterKeys().size());
     }
+
+    @Test(expected = IllegalStateException.class)
+    public void messageExceedsMaxHeaderSize() {
+        final byte[] out = new byte[1];
+        final byte[] testHeaders = getTestHeaders();
+        final DecryptionHandler decryptionHandler = DecryptionHandler.create(new DefaultCryptoMaterialsManager(keyring), null, 1);
+        decryptionHandler.processBytes(testHeaders, 0, testHeaders.length, out, 0);
+    }
+
+    public void messageAtMaxHeaderSize() {
+        final byte[] out = new byte[1];
+        final byte[] testHeaders = getTestHeaders();
+        final DecryptionHandler decryptionHandler = DecryptionHandler.create(new DefaultCryptoMaterialsManager(keyring), null, testHeaders.length);
+        ProcessingSummary summary = decryptionHandler.processBytes(testHeaders, 0, testHeaders.length, out, 0);
+        assertEquals(testHeaders.length, summary.getBytesProcessed());
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* #205 

TODOs:

- more unit test coverage
- Strengthen assurance around "possible" int overflow
- Is there a way to further simplify the maxHeaderSize logic? Right now it's concise but a bit hard to understand.
- Is there a better approach to plumb these params through to the decryption handlers?

Note: I'm publishing this as one PR to save time (I implemented the two params at the same time), but once we prioritize getting this in I can separate this into two PRs (one for each param) to make reviewing easier.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

