### PR TITLE
chore: Clarify KmsMasterKeyProvider Strict behavior in docs

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -245,10 +245,17 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
 
         /**
          * Builds the master key provider in Strict Mode.
-         * KMS Master Key Providers in Strict Mode will only attempt to decrypt using the
-         * keys listed in {@code keyIds}.
+         * KMS Master Key Providers in Strict Mode will only attempt to decrypt using
+         * key ARNs listed in {@code keyIds}.
          * KMS Master Key Providers in Strict Mode will encrypt data keys using the keys
          * listed in {@code keyIds}
+         *
+         * In Strict Mode, one or more CMKs must be provided.
+         * For providers that will only be used for encryption,
+         * you can use any valid KMS key identifier.
+         * For providers that will be used for decryption,
+         * you must use the key ARN;
+         * key ids, alias names, and alias ARNs are not supported.
          *
          * @param keyIds
          * @return
@@ -267,10 +274,17 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
 
         /**
          * Builds the master key provider in strict mode.
-         * KMS Master Key Providers in Strict Mode will only attempt to decrypt using the
-         * keys listed in {@code keyIds}.
+         * KMS Master Key Providers in Strict Mode will only attempt to decrypt using
+         * key ARNs listed in {@code keyIds}.
          * KMS Master Key Providers in Strict Mode will encrypt data keys using the keys
          * listed in {@code keyIds}
+         *
+         * In Strict Mode, one or more CMKs must be provided.
+         * For providers that will only be used for encryption,
+         * you can use any valid KMS key identifier.
+         * For providers that will be used for decryption,
+         * you must use the key ARN;
+         * key ids, alias names, and alias ARNs are not supported.
          *
          * @param keyIds
          * @return


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* We've seen confusion in other SDKs about this behavior. In Java we state pretty clearly this in the examples, but do not mention it directly in the KmsMasterKeyProvider docs. This fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

