### PR TITLE
test: fix ParsedCiphertextTest, add to AllTestsSuite

### DIFF
--- a/src/test/java/com/amazonaws/encryptionsdk/AllTestsSuite.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AllTestsSuite.java
@@ -89,7 +89,8 @@ import com.amazonaws.encryptionsdk.kms.KmsMasterKeyTest;
         RestrictRegionExampleTest.class,
         SimpleDataKeyCachingExampleTest.class,
         SetEncryptionAlgorithmExampleTest.class,
-        SetCommitmentPolicyExampleTest.class
+        SetCommitmentPolicyExampleTest.class,
+        ParsedCiphertextTest.class,
 })
 public class AllTestsSuite {
 }

--- a/src/test/java/com/amazonaws/encryptionsdk/ParsedCiphertextTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/ParsedCiphertextTest.java
@@ -25,7 +25,7 @@ public class ParsedCiphertextTest extends CiphertextHeaders {
     public void init() {
         masterKeyProvider = spy(new StaticMasterKey("testmaterial"));
 
-        encryptionClient_ = AwsCrypto.standard();
+        encryptionClient_ = AwsCrypto.builder().withCommitmentPolicy(CommitmentPolicy.ForbidEncryptAllowDecrypt).build();
         encryptionClient_.setEncryptionAlgorithm(CryptoAlgorithm.ALG_AES_128_GCM_IV12_TAG16_HKDF_SHA256);
     }
 


### PR DESCRIPTION
*Description of changes:*

* Explicitly set a CommitmentPolicy in ParsedCiphertextTest in order to fix configuration conflict error when running the test.
* Add ParsedCiphertextTest to AllTestsSuite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

