### PR TITLE
chore: Add initial codebuild specs for automating release

### DIFF
--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -1,0 +1,65 @@
+version: 0.2
+
+env:
+  secrets-manager:
+    SONA_USERNAME: Sonatype-Team-Account:Username 
+    SONA_PASS: Sonatype-Team-Account:Password
+
+phases:
+  install:
+    runtime-versions:
+      java: openjdk8
+  pre_build:
+    commands:
+      - git checkout $COMMIT_ID
+      - FOUND_VERSION=$(grep version pom.xml | head -n 1 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+      - |
+        if expr ${FOUND_VERSION} != ${VERSION}; then
+          echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
+          exit 1;
+        fi
+  build:
+    commands:
+      - echo "Doing nothing, release step is currently a no-op"
+
+
+batch:
+  fast-fail: false
+  build-graph:
+    - identifier: release_to_prod
+    - identifier: validate_prod_release_openjdk8
+      depend-on:
+        - release_to_prod
+      buildspec: codebuild/release/validate-prod.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: openjdk8
+          JAVA_NUMERIC_VERSION: 8
+        image: aws/codebuild/standard:3.0
+    - identifier: validate_prod_release_openjdk11
+      depend-on:
+        - release_to_prod
+      buildspec: codebuild/release/validate-prod.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: openjdk11
+          JAVA_NUMERIC_VERSION: 11
+        image: aws/codebuild/standard:3.0
+    - identifier: validate_prod_release_corretto8
+      depend-on:
+        - release_to_prod
+      buildspec: codebuild/release/validate-prod.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: corretto8
+          JAVA_NUMERIC_VERSION: 8
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    - identifier: validate_prod_release_corretto11
+      depend-on:
+        - release_to_prod
+      buildspec: codebuild/release/validate-prod.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: corretto11
+          JAVA_NUMERIC_VERSION: 11
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -1,0 +1,65 @@
+version: 0.2
+
+env:
+  secrets-manager:
+    SONA_USERNAME: Sonatype-Team-Account:Username 
+    SONA_PASS: Sonatype-Team-Account:Password
+
+phases:
+  install:
+    runtime-versions:
+      java: openjdk8
+  pre_build:
+    commands:
+      - git checkout $COMMIT_ID
+      - FOUND_VERSION=$(grep version pom.xml | head -n 1 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+      - |
+        if expr ${FOUND_VERSION} != ${VERSION}; then
+          echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
+          exit 1;
+        fi
+  build:
+    commands:
+      - echo "Doing nothing, release step is currently a no-op"
+
+
+batch:
+  fast-fail: false
+  build-graph:
+    - identifier: release_to_staging
+    - identifier: validate_staging_release_openjdk8
+      depend-on:
+        - release_to_staging
+      buildspec: codebuild/release/validate-staging.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: openjdk8
+          JAVA_NUMERIC_VERSION: 8
+        image: aws/codebuild/standard:3.0
+    - identifier: validate_staging_release_openjdk11
+      depend-on:
+        - release_to_staging
+      buildspec: codebuild/release/validate-staging.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: openjdk11
+          JAVA_NUMERIC_VERSION: 11
+        image: aws/codebuild/standard:3.0
+    - identifier: validate_staging_release_corretto8
+      depend-on:
+        - release_to_staging
+      buildspec: codebuild/release/validate-staging.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: corretto8
+          JAVA_NUMERIC_VERSION: 8
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    - identifier: validate_staging_release_corretto11
+      depend-on:
+        - release_to_staging
+      buildspec: codebuild/release/validate-staging.yml
+      env:
+        variables:
+          JAVA_ENV_VERSION: corretto11
+          JAVA_NUMERIC_VERSION: 11
+        image: aws/codebuild/amazonlinux2-x86_64-standard:3.0

--- a/codebuild/release/settings.xml
+++ b/codebuild/release/settings.xml
@@ -1,0 +1,26 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                                  http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>codeartifact</id>
+      <username>aws</username>
+      <password>${codeartifact.token}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>codeartifact</id>
+      <repositories>
+        <repository>
+          <id>codeartifact</id>
+          <name>codeartifact</name>
+          <url>${codeartifact.url}</url> <!-- passed via command line to avoid hardcoding it here -->
+        </repository>
+      </repositories>
+    </profile>
+  </profiles>
+
+</settings>

--- a/codebuild/release/validate-prod.yml
+++ b/codebuild/release/validate-prod.yml
@@ -1,0 +1,18 @@
+version: 0.2
+
+phases:
+  install:
+    runtime-versions:
+      java: $JAVA_ENV_VERSION
+  pre_build:
+    commands:
+      - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
+      - cd busy-engineers-document-bucket/exercises/java/encryption-context-complete
+  build:
+    commands:
+      - |
+        mvn verify \
+          -Dcheckstyle.skip \
+          -Desdk.version=$VERSION \
+          -Dmaven.compiler.target=$JAVA_NUMERIC_VERSION \
+          -Dmaven.compiler.source=$JAVA_NUMERIC_VERSION

--- a/codebuild/release/validate-staging.yml
+++ b/codebuild/release/validate-staging.yml
@@ -1,0 +1,36 @@
+version: 0.2
+
+env:
+  variables:
+    REGION: us-east-1
+    DOMAIN: crypto-tools-internal
+    REPOSITORY: java-esdk-staging
+  parameter-store:
+    ACCOUNT: /CodeBuild/AccountId
+
+phases:
+  install:
+    commands:
+      - pip install awscli
+    runtime-versions:
+      java: $JAVA_ENV_VERSION
+  pre_build:
+    commands:
+      - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
+      - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
+      - cd busy-engineers-document-bucket/exercises/java/encryption-context-complete
+      - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
+      - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
+  build:
+    commands:
+      - |
+        mvn verify \
+          -Pcodeartifact \
+          -Dcheckstyle.skip \
+          -Desdk.version=$VERSION \
+          -Dmaven.compiler.target=$JAVA_NUMERIC_VERSION \
+          -Dmaven.compiler.source=$JAVA_NUMERIC_VERSION \
+          -Dcodeartifact.token=$CODEARTIFACT_TOKEN \
+          -Dcodeartifact.url=$CODEARTIFACT_REPO_URL \
+          -s $SETTINGS_FILE
+


### PR DESCRIPTION
*Description of changes:*
For now, these specs only deal with validation. However, I'm using the structure that includes a place for the release itself (currently a no-op) so that we can easily add that once we're ready.

Unlike in the Python ESDK, I made separate files for validation of prod vs staging releases, since the steps to hit the staging repository are a pretty big delta from hitting normal public repos.

*Testing:*
I've tested both the prod and release targets, including staging a version not on public maven to make extra sure that the staging validation is actually hitting the staging repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

