### PR TITLE
chore: Automate staging and production release using CodeBuild as well

### DIFF
--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -5,7 +5,7 @@ env:
     GPG_KEY: Maven-GPG-Keys-Credentials:Keyname
     GPG_PASS: Maven-GPG-Keys-Credentials:Passphrase
     SONA_USERNAME: Sonatype-Team-Account:Username 
-    SONA_PASS: Sonatype-Team-Account:Password
+    SONA_PASSWORD: Sonatype-Team-Account:Password
 
 phases:
   install:

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -2,13 +2,15 @@ version: 0.2
 
 env:
   secrets-manager:
+    GPG_KEY: Maven-GPG-Keys-Credentials:Keyname
+    GPG_PASS: Maven-GPG-Keys-Credentials:Passphrase
     SONA_USERNAME: Sonatype-Team-Account:Username 
     SONA_PASS: Sonatype-Team-Account:Password
 
 phases:
   install:
     runtime-versions:
-      java: openjdk8
+      java: openjdk11
   pre_build:
     commands:
       - git checkout $COMMIT_ID
@@ -18,9 +20,23 @@ phases:
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
+      - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:
-      - echo "Doing nothing, release step is currently a no-op"
+      - |
+        mvn deploy \
+          -PpublishingCodeArtifact \
+          -Pfast-tests-only \
+          -DperformRelease \
+          -Dgpg.homedir="$HOME/mvn_gpg" \
+          -DautoReleaseAfterClose=true \
+          -Dgpg.keyname="$GPG_KEY" \
+          -Dgpg.passphrase="$GPG_PASS" \
+          -Dsonatype.username="$SONA_USERNAME" \
+          -Dsonatype.password="$SONA_PASSWORD" \
+          -s $SETTINGS_FILE
 
 
 batch:

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -27,7 +27,7 @@ phases:
     commands:
       - |
         mvn deploy \
-          -PpublishingCodeArtifact \
+          -Ppublishing \
           -Pfast-tests-only \
           -DperformRelease \
           -Dgpg.homedir="$HOME/mvn_gpg" \

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -5,7 +5,6 @@ env:
     REGION: us-east-1
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-esdk-staging
-    JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     MVN_GPG: mvn_gpg
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -26,6 +26,7 @@ phases:
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
+      - sudo apt-get install gnupg
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -15,7 +15,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: openjdk8
+      java: corretto11
   pre_build:
     commands:
       - git checkout $COMMIT_ID

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -5,7 +5,7 @@ env:
     REGION: us-east-1
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-esdk-staging
-    MVN_GPG: $HOME/mvn_gpg
+    MVN_GPG: mvn_gpg
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
   secrets-manager:
@@ -27,8 +27,8 @@ phases:
         fi
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
-      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz
-      - tar -xvf mvn_gpg.tgz
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - tar -xvf ~/mvn_gpg.tgz
   build:
     commands:
       - |
@@ -36,7 +36,7 @@ phases:
           -PpublishingCodeArtifact \
           -Pfast-tests-only \
           -DperformRelease \
-          -Dgpg.homedir="$MVN_GPG" \
+          -Dgpg.homedir="$HOME/$MVN_GPG" \
           -DautoReleaseAfterClose=true \
           -Dgpg.keyname="$GPG_KEY" \
           -Dgpg.passphrase="$GPG_PASS" \

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -28,7 +28,7 @@ phases:
       # - apt remove gpg -y
       # - apt install gpg -y
       - gpg --version
-      - gpg-agent --daemon
+      - gpg-agent --homedir "$CODEBUILD_SRC_DIR/$MVN_GPG" --daemon
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -6,7 +6,7 @@ env:
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-esdk-staging
     JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
-    MVN_GPG: ~/mvn_gpg
+    MVN_GPG: mvn_gpg
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
   secrets-manager:
@@ -28,8 +28,8 @@ phases:
         fi
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
-      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
-      - tar -xvf ~/mvn_gpg.tgz -C ~
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz
+      - tar -xvf mvn_gpg.tgz
   build:
     commands:
       - |
@@ -37,7 +37,7 @@ phases:
           -PpublishingCodeArtifact \
           -Pfast-tests-only \
           -DperformRelease \
-          -Dgpg.homedir="$MVN_GPG" \
+          -Dgpg.homedir="$CODEBUILD_SRC_DIR/$MVN_GPG" \
           -DautoReleaseAfterClose=true \
           -Dgpg.keyname="$GPG_KEY" \
           -Dgpg.passphrase="$GPG_PASS" \

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -5,7 +5,7 @@ env:
     REGION: us-east-1
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-esdk-staging
-    MVN_GPG: mvn_gpg
+    MVN_GPG: $HOME/mvn_gpg
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
   secrets-manager:
@@ -25,10 +25,6 @@ phases:
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
-      # - apt remove gpg -y
-      # - apt install gpg -y
-      - gpg --version
-      - gpg-agent --homedir "$CODEBUILD_SRC_DIR/$MVN_GPG" --daemon
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz
@@ -40,7 +36,7 @@ phases:
           -PpublishingCodeArtifact \
           -Pfast-tests-only \
           -DperformRelease \
-          -Dgpg.homedir="$CODEBUILD_SRC_DIR/$MVN_GPG" \
+          -Dgpg.homedir="$MVN_GPG" \
           -DautoReleaseAfterClose=true \
           -Dgpg.keyname="$GPG_KEY" \
           -Dgpg.passphrase="$GPG_PASS" \

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -26,7 +26,7 @@ phases:
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
-      - sudo apt-get install gnupg
+      - apt-get install gnupg
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -5,6 +5,7 @@ env:
     REGION: us-east-1
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-esdk-staging
+    ROLE: Admin
     MVN_GPG: mvn_gpg
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -5,8 +5,6 @@ env:
     REGION: us-east-1
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-esdk-staging
-    ROLE: Admin
-    MVN_GPG: mvn_gpg
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
   secrets-manager:
@@ -16,7 +14,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: corretto11
+      java: openjdk11
   pre_build:
     commands:
       - git checkout $COMMIT_ID
@@ -38,7 +36,7 @@ phases:
           -PpublishingCodeArtifact \
           -Pfast-tests-only \
           -DperformRelease \
-          -Dgpg.homedir="$HOME/$MVN_GPG" \
+          -Dgpg.homedir="$HOME/mvn_gpg" \
           -DautoReleaseAfterClose=true \
           -Dgpg.keyname="$GPG_KEY" \
           -Dgpg.passphrase="$GPG_PASS" \

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -28,6 +28,7 @@ phases:
       # - apt remove gpg -y
       # - apt install gpg -y
       - gpg --version
+      - gpg-agent --daemon
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -35,6 +35,7 @@ phases:
       - |
         mvn deploy \
           -PpublishingCodeArtifact \
+          -Pfast-tests-only \
           -DperformRelease \
           -Dgpg.homedir="$MVN_GPG" \
           -DautoReleaseAfterClose=true \

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -5,7 +5,7 @@ env:
     REGION: us-east-1
     DOMAIN: crypto-tools-internal
     REPOSITORY: java-esdk-staging
-    JAVA_HOME: /usr/lib/jvm/default-java
+    JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64
     MVN_GPG: ~/mvn_gpg
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -25,8 +25,8 @@ phases:
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
-      - apt remove gpg
-      - apt install gnupg1
+      - apt remove gpg -y
+      - apt install gnupg1 -y
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -25,7 +25,8 @@ phases:
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
-      - apt-get install gnupg
+      - apt remove gpg
+      - apt install gnupg1
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -26,7 +26,7 @@ phases:
           exit 1;
         fi
       - apt remove gpg -y
-      - apt install gnupg -y
+      - apt install gpg -y
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -1,9 +1,17 @@
 version: 0.2
 
 env:
+  variables:
+    REGION: us-east-1
+    DOMAIN: crypto-tools-internal
+    REPOSITORY: java-esdk-staging
+    JAVA_HOME: /usr/lib/jvm/default-java
+    MVN_GPG: ~/mvn_gpg
+  parameter-store:
+    ACCOUNT: /CodeBuild/AccountId
   secrets-manager:
-    SONA_USERNAME: Sonatype-Team-Account:Username 
-    SONA_PASS: Sonatype-Team-Account:Password
+    GPG_KEY: Maven-GPG-Keys-Credentials:Keyname
+    GPG_PASS: Maven-GPG-Keys-Credentials:Passphrase
 
 phases:
   install:
@@ -18,10 +26,22 @@ phases:
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
+      - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
+      - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:
-      - echo "Doing nothing, release step is currently a no-op"
-
+      - |
+        mvn deploy \
+          -PpublishingCodeArtifact \
+          -DperformRelease \
+          -Dgpg.homedir="$MVN_GPG" \
+          -DautoReleaseAfterClose=true \
+          -Dgpg.keyname="$GPG_KEY" \
+          -Dgpg.passphrase="$GPG_PASS" \
+          -Dcodeartifact.token=$CODEARTIFACT_TOKEN \
+          -DaltDeploymentRepository=codeartifact::default::$CODEARTIFACT_REPO_URL
 
 batch:
   fast-fail: false

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -28,7 +28,7 @@ phases:
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
-      - tar -xvf ~/mvn_gpg.tgz
+      - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:
       - |

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -26,6 +26,7 @@ phases:
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
+      - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
@@ -42,7 +43,8 @@ phases:
           -Dgpg.keyname="$GPG_KEY" \
           -Dgpg.passphrase="$GPG_PASS" \
           -Dcodeartifact.token=$CODEARTIFACT_TOKEN \
-          -DaltDeploymentRepository=codeartifact::default::$CODEARTIFACT_REPO_URL
+          -DaltDeploymentRepository=codeartifact::default::$CODEARTIFACT_REPO_URL \
+          -s $SETTINGS_FILE
 
 batch:
   fast-fail: false

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -25,8 +25,9 @@ phases:
           echo "pom.xml version (${FOUND_VERSION}) does not match expected version (${VERSION}), stopping"
           exit 1;
         fi
-      - apt remove gpg -y
-      - apt install gpg -y
+      # - apt remove gpg -y
+      # - apt install gpg -y
+      - gpg --version
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -26,7 +26,7 @@ phases:
           exit 1;
         fi
       - apt remove gpg -y
-      - apt install gnupg1 -y
+      - apt install gnupg -y
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > mvn_gpg.tgz

--- a/codebuild/release/settings.xml
+++ b/codebuild/release/settings.xml
@@ -8,6 +8,11 @@
       <username>aws</username>
       <password>${codeartifact.token}</password>
     </server>
+    <server>
+      <id>sonatype-nexus-staging</id>
+      <username>${sonatype.username}</username>
+      <password>${sonatype.password}</password>
+    </server>
   </servers>
 
   <profiles>


### PR DESCRIPTION
*Description of changes:*

This fills in the no-op steps to publish artifacts to either staging (i.e. CodeArtifact) or production (i.e. Sonatype).

*Testing:*

The staging workflow works completely with an existing release (if not already present on CodeArtifact), and the production workflow fails as expected because the latest version is already publicly released.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

