### PR TITLE
chore: source controlling cfn templates that will be used for our release process

### DIFF
--- a/cfn/code_artifact.yml
+++ b/cfn/code_artifact.yml
@@ -1,3 +1,5 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
 AWSTemplateFormatVersion: 2010-09-09
 Description: "Template for CodeArtifact repositories. Creates Domain if CreateDomainFlag is True"
 Parameters:

--- a/cfn/code_artifact.yml
+++ b/cfn/code_artifact.yml
@@ -1,0 +1,42 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: "Template for CodeArtifact repositories. Creates Domain if CreateDomainFlag is True"
+Parameters:
+  DomainName:
+    Type: String
+    Description: The name of the CodeArtifact Domain
+    Default: crypto-tools-internal
+  RepositoryName:
+    Type: String
+    Description: Base Name for the Repositories
+    Default: esdk-java
+  CreateDomainFlag:
+    Type: String
+    Description: Attempt to create Domain or not
+    Default: False
+    AllowedValues:
+      - True
+      - False
+
+Conditions:
+  CreateDomain: !Equals
+    - !Ref CreateDomainFlag
+    - True
+
+Resources:
+  Domain:
+    Type: AWS::CodeArtifact::Domain
+    Condition: CreateDomain
+    Properties:
+      DomainName: !Ref DomainName
+
+  CIRepo:
+    Type: AWS::CodeArtifact::Repository
+    Properties:
+      DomainName: !Ref DomainName
+      RepositoryName: !Sub "${RepositoryName}-ci"
+
+  StagingRepo:
+    Type: AWS::CodeArtifact::Repository
+    Properties:
+      DomainName: !Ref DomainName
+      RepositoryName: !Sub "${RepositoryName}-staging"

--- a/cfn/code_build_parameter_map.json
+++ b/cfn/code_build_parameter_map.json
@@ -1,0 +1,6 @@
+{
+  "NumberOfBuildsInBatch": 50,
+  "ProjectDescription": "CD for Java ESDK",
+  "ProjectName": "java-esdk",
+  "SourceLocation": "https://github.com/aws/aws-encryption-sdk-java.git"
+}

--- a/cfn/prod-release.yml
+++ b/cfn/prod-release.yml
@@ -1,0 +1,264 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: >-
+  Template to build a CodeBuild Project, assumes that GitHub credentials are
+  already set up.
+Parameters:
+  ProjectName:
+    Type: String
+    Description: The name of the CodeBuild Project
+    Default: java-esdk-prod
+  ProjectDescription:
+    Type: String
+    Description: The description for the CodeBuild Project
+    Default: CFN stack for managing CodeBuild Release project for the ESDK-Java
+  SourceLocation:
+    Type: String
+    Description: The https GitHub URL for the project
+    Default: "https://github.com/aws/aws-encryption-sdk-java.git"
+  NumberOfBuildsInBatch:
+    Type: Number
+    MaxValue: 100
+    MinValue: 1
+    Default: 10
+    Description: The number of builds you expect to run in a batch
+Metadata:
+  "AWS::CloudFormation::Interface":
+    ParameterGroups:
+      - Label:
+          default: Crypto Tools CodeBuild Project Template
+        Parameters:
+          - ProjectName
+          - ProjectDescription
+          - SourceLocation
+Resources:
+  CodeBuildProjectRelease:
+    Type: "AWS::CodeBuild::Project"
+    Properties:
+      Name: !Sub "${ProjectName}-release-prod"
+      Description: !Sub "CodeBuild project for ${ProjectName} to release to Sonatype."
+      Source:
+        Location: !Ref SourceLocation
+        BuildSpec: codebuild/release/prod-release.yml
+        GitCloneDepth: 1
+        GitSubmodulesConfig:
+          FetchSubmodules: false
+        InsecureSsl: false
+        ReportBuildStatus: false
+        Type: GITHUB
+      Artifacts:
+        Type: NO_ARTIFACTS
+      Cache:
+        Type: NO_CACHE
+      Environment:
+        ComputeType: BUILD_GENERAL1_LARGE
+        Image: "aws/codebuild/standard:4.0"
+        ImagePullCredentialsType: CODEBUILD
+        PrivilegedMode: false
+        Type: LINUX_CONTAINER
+      ServiceRole: !GetAtt CodeBuildServiceRole.Arn
+      TimeoutInMinutes: 60
+      QueuedTimeoutInMinutes: 480
+      EncryptionKey: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/s3"
+      BadgeEnabled: false
+      BuildBatchConfig:
+        ServiceRole: !GetAtt CodeBuildServiceRole.Arn
+        Restrictions:
+          MaximumBuildsAllowed: !Ref NumberOfBuildsInBatch
+          ComputeTypesAllowed:
+            - BUILD_GENERAL1_SMALL
+            - BUILD_GENERAL1_MEDIUM
+            - BUILD_GENERAL1_LARGE
+        TimeoutInMins: 480
+      LogsConfig:
+        CloudWatchLogs:
+          Status: ENABLED
+        S3Logs:
+          Status: DISABLED
+          EncryptionDisabled: false
+    Metadata:
+      "AWS::CloudFormation::Designer":
+        id: 46a42d6b-ae90-4ac0-8adf-e529eef5e9ac
+  CodeBuildServiceRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      Path: /service-role/
+      RoleName: !Sub "codebuild-${ProjectName}-service-role"
+      AssumeRolePolicyDocument: >-
+        {"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"codebuild.amazonaws.com"},"Action":"sts:AssumeRole"}]}
+      MaxSessionDuration: 3600
+      ManagedPolicyArns:
+        - !Ref CryptoToolsKMS
+        - !Ref CodeBuildBatchPolicy
+        - !Ref CodeBuildBasePolicy
+        - !Ref SecretsManagerPolicy
+        - !Ref ParameterStorePolicy
+        - "arn:aws:iam::aws:policy/AWSCodeArtifactReadOnlyAccess"
+        - "arn:aws:iam::aws:policy/AWSCodeArtifactAdminAccess"
+    Metadata:
+      "AWS::CloudFormation::Designer":
+        id: 19b17bdc-5d49-4f12-93e6-6d761b7ce324
+  CodeBuildBatchPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      ManagedPolicyName: !Sub >-
+        CodeBuildBuildBatchPolicy-${ProjectName}-${AWS::Region}-codebuild-${ProjectName}-service-role
+      Path: /service-role/
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${ProjectName}-test-release",
+                "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${ProjectName}-prod-release",
+                "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/${ProjectName}"
+              ],
+              "Action": [
+                "codebuild:StartBuild",
+                "codebuild:StopBuild",
+                "codebuild:RetryBuild"
+              ]
+            }
+          ]
+        }
+    Metadata:
+      "AWS::CloudFormation::Designer":
+        id: 894a45c5-5dc7-4f11-be65-8bf5e37e289d
+  CodeBuildBasePolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      ManagedPolicyName: !Sub "CodeBuildBasePolicy-${ProjectName}-${AWS::Region}"
+      Path: /service-role/
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ProjectName}",
+                "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ProjectName}:*",
+                "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ProjectName}-test-release",
+                "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ProjectName}-test-release:*",
+                "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ProjectName}-prod-release",
+                "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/${ProjectName}-prod-release:*"
+              ],
+              "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+              ]
+            },
+            {
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:s3:::codepipeline-${AWS::Region}-*"
+              ],
+              "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:GetObjectVersion",
+                "s3:GetBucketAcl",
+                "s3:GetBucketLocation"
+              ]
+            },
+            {
+              "Effect": "Allow",
+              "Action": [
+                "codebuild:CreateReportGroup",
+                "codebuild:CreateReport",
+                "codebuild:UpdateReport",
+                "codebuild:BatchPutTestCases",
+                "codebuild:BatchPutCodeCoverages"
+              ],
+              "Resource": [
+                "arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:report-group/${ProjectName}-*"
+              ]
+            }
+          ]
+        }
+    Metadata:
+      "AWS::CloudFormation::Designer":
+        id: 3dafd088-2792-4a41-b612-d9d049721644
+  AccountIdParameter:
+    Type: "AWS::SSM::Parameter"
+    Properties:
+      Description: Parameter to store our account id so CodeBuild specs can access it
+      Name: /CodeBuild/AccountId
+      Type: String
+      Value: !Sub "${AWS::AccountId}"
+    Metadata:
+      "AWS::CloudFormation::Designer":
+        id: 845aaadf-b869-42fa-90d5-c2557829b55e
+  SecretsManagerPolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      ManagedPolicyName: !Sub "CryptoTools-SecretsManager-${ProjectName}-release"
+      Path: /service-role/
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-GC6h0A",
+                "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-Team-Account-0tWvZm",
+                "arn:aws:secretsmanager:us-west-2:587316601012:secret:Maven-GPG-Keys-Credentials-C0wCzI",
+              ],
+              "Action": "secretsmanager:GetSecretValue"
+            }
+          ]
+        }
+    Metadata:
+      "AWS::CloudFormation::Designer":
+        id: 41e195f9-22c7-44b7-9793-0232701f6223
+  CryptoToolsKMS:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      ManagedPolicyName: !Sub >-
+        CrypotToolsKMSPolicy-${ProjectName}-${AWS::Region}-codebuild-${ProjectName}-service-role
+      Path: /service-role/
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:kms:*:658956600833:key/*",
+                "arn:aws:kms:*:658956600833:alias/*"
+              ],
+              "Action": [
+                "kms:Encrypt",
+                "kms:Decrypt",
+                "kms:GenerateDataKey"
+              ]
+            }
+          ]
+        }
+    Metadata:
+      "AWS::CloudFormation::Designer":
+        id: dd99a5ab-b579-4f13-a80f-d72c35896892
+  ParameterStorePolicy:
+    Type: "AWS::IAM::ManagedPolicy"
+    Properties:
+      ManagedPolicyName: !Sub "CryptoTools-ParameterStore-${ProjectName}-release"
+      Path: /service-role/
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/CodeBuild/*"
+              ],
+              "Action": "ssm:GetParameters"
+            }
+          ]
+        }
+    Metadata:
+      "AWS::CloudFormation::Designer":
+        id: f67609eb-975a-4747-8065-aea5b1fc038d

--- a/cfn/prod-release.yml
+++ b/cfn/prod-release.yml
@@ -1,3 +1,6 @@
+# Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Template to build a CodeBuild Project, assumes that GitHub credentials are
@@ -75,9 +78,6 @@ Resources:
         S3Logs:
           Status: DISABLED
           EncryptionDisabled: false
-    Metadata:
-      "AWS::CloudFormation::Designer":
-        id: 46a42d6b-ae90-4ac0-8adf-e529eef5e9ac
   CodeBuildServiceRole:
     Type: "AWS::IAM::Role"
     Properties:
@@ -94,9 +94,6 @@ Resources:
         - !Ref ParameterStorePolicy
         - "arn:aws:iam::aws:policy/AWSCodeArtifactReadOnlyAccess"
         - "arn:aws:iam::aws:policy/AWSCodeArtifactAdminAccess"
-    Metadata:
-      "AWS::CloudFormation::Designer":
-        id: 19b17bdc-5d49-4f12-93e6-6d761b7ce324
   CodeBuildBatchPolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
@@ -122,9 +119,6 @@ Resources:
             }
           ]
         }
-    Metadata:
-      "AWS::CloudFormation::Designer":
-        id: 894a45c5-5dc7-4f11-be65-8bf5e37e289d
   CodeBuildBasePolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
@@ -178,9 +172,6 @@ Resources:
             }
           ]
         }
-    Metadata:
-      "AWS::CloudFormation::Designer":
-        id: 3dafd088-2792-4a41-b612-d9d049721644
   AccountIdParameter:
     Type: "AWS::SSM::Parameter"
     Properties:
@@ -188,9 +179,6 @@ Resources:
       Name: /CodeBuild/AccountId
       Type: String
       Value: !Sub "${AWS::AccountId}"
-    Metadata:
-      "AWS::CloudFormation::Designer":
-        id: 845aaadf-b869-42fa-90d5-c2557829b55e
   SecretsManagerPolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
@@ -211,9 +199,6 @@ Resources:
             }
           ]
         }
-    Metadata:
-      "AWS::CloudFormation::Designer":
-        id: 41e195f9-22c7-44b7-9793-0232701f6223
   CryptoToolsKMS:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
@@ -238,9 +223,6 @@ Resources:
             }
           ]
         }
-    Metadata:
-      "AWS::CloudFormation::Designer":
-        id: dd99a5ab-b579-4f13-a80f-d72c35896892
   ParameterStorePolicy:
     Type: "AWS::IAM::ManagedPolicy"
     Properties:
@@ -259,6 +241,3 @@ Resources:
             }
           ]
         }
-    Metadata:
-      "AWS::CloudFormation::Designer":
-        id: f67609eb-975a-4747-8065-aea5b1fc038d


### PR DESCRIPTION
*Description of changes:*
code_artifact.yml and code_build_parameter_map.json are the same files that live in the [cfn](https://github.com/aws/private-aws-encryption-sdk-java-staging/tree/infra/cfn) branch of the private repos 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

