### PR TITLE
chore: Add back removed CiphertextHeaders.deserialize method

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
@@ -503,7 +503,6 @@ public class CiphertextHeaders {
     return 0;
   }
 
-
   /**
    * Deserialize the provided bytes starting at the specified offset to construct an instance of
    * this class. Uses the default value for maxEncryptedDataKeys, which results in no limit.
@@ -520,20 +519,20 @@ public class CiphertextHeaders {
     return deserialize(b, off, NO_MAX_ENCRYPTED_DATA_KEYS);
   }
 
-    /**
-     * Deserialize the provided bytes starting at the specified offset to construct an instance of
-     * this class.
-     *
-     * <p>This method parses the provided bytes for the individual fields in this class. This method
-     * also supports partial parsing where not all the bytes required for parsing the fields
-     * successfully are available.
-     *
-     * @param b the byte array to deserialize.
-     * @param off the offset in the byte array to use for deserialization.
-     * @param maxEncryptedDataKeys the maximum number of EDKs to deserialize; zero indicates no
-     *     maximum
-     * @return the number of bytes consumed in deserialization.
-     */
+  /**
+   * Deserialize the provided bytes starting at the specified offset to construct an instance of
+   * this class.
+   *
+   * <p>This method parses the provided bytes for the individual fields in this class. This method
+   * also supports partial parsing where not all the bytes required for parsing the fields
+   * successfully are available.
+   *
+   * @param b the byte array to deserialize.
+   * @param off the offset in the byte array to use for deserialization.
+   * @param maxEncryptedDataKeys the maximum number of EDKs to deserialize; zero indicates no
+   *     maximum
+   * @return the number of bytes consumed in deserialization.
+   */
   public int deserialize(final byte[] b, final int off, int maxEncryptedDataKeys)
       throws ParseException {
     if (b == null) {
@@ -853,8 +852,7 @@ public class CiphertextHeaders {
   }
 
   /**
-   * Return max encrypted data keys
-   * Package scope for unit testing.
+   * Return max encrypted data keys. Package scope for unit testing.
    *
    * @return int
    */

--- a/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
@@ -61,8 +61,7 @@ public class CiphertextHeadersTest {
 
       final byte[] headerBytes = ciphertextHeaders.toByteArray();
       final CiphertextHeaders reconstructedHeaders = new CiphertextHeaders();
-      reconstructedHeaders.deserialize(
-              headerBytes, 0, maxEncryptedDataKeys);
+      reconstructedHeaders.deserialize(headerBytes, 0, maxEncryptedDataKeys);
       final byte[] reconstructedHeaderBytes = reconstructedHeaders.toByteArray();
 
       assertEquals(reconstructedHeaders.getMaxEncryptedDataKeys(), maxEncryptedDataKeys);
@@ -83,7 +82,9 @@ public class CiphertextHeadersTest {
       reconstructedHeaders.deserialize(headerBytes, 0);
       final byte[] reconstructedHeaderBytes = reconstructedHeaders.toByteArray();
 
-      assertEquals(reconstructedHeaders.getMaxEncryptedDataKeys(), CiphertextHeaders.NO_MAX_ENCRYPTED_DATA_KEYS);
+      assertEquals(
+          reconstructedHeaders.getMaxEncryptedDataKeys(),
+          CiphertextHeaders.NO_MAX_ENCRYPTED_DATA_KEYS);
       assertArrayEquals(headerBytes, reconstructedHeaderBytes);
     }
   }


### PR DESCRIPTION
*Description of changes:*
When we added the `maxEncryptedDataKeys` parameter to the deserialize method, any customers previously parsing the returned headers would have had to change their code to adhere to the new interface. This change brings back the original API to preserve backwards compatibility, assuming a default value for the `maxEncryptedDataKeys` value (0, which results in no limit).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

