### PR TITLE
chore: Add back removed CiphertextHeaders.deserialize method (1.x)

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/model/CiphertextHeaders.java
@@ -521,13 +521,34 @@ public class CiphertextHeaders {
 
     /**
      * Deserialize the provided bytes starting at the specified offset to
-     * construct an instance of this class.
-     * 
+     * construct an instance of this class. Uses the default value for
+     * maxEncryptedDataKeys, which results in no limit.
+     *
      * <p>
      * This method parses the provided bytes for the individual fields in this
      * class. This methods also supports partial parsing where not all the bytes
      * required for parsing the fields successfully are available.
-     * 
+     *
+     * @param b
+     *            the byte array to deserialize.
+     * @param off
+     *            the offset in the byte array to use for deserialization.
+     * @return
+     *         the number of bytes consumed in deserialization.
+     */
+    public int deserialize(final byte[] b, final int off) throws ParseException {
+        return deserialize(b, off, NO_MAX_ENCRYPTED_DATA_KEYS);
+    }
+
+    /**
+     * Deserialize the provided bytes starting at the specified offset to
+     * construct an instance of this class.
+     *
+     * <p>
+     * This method parses the provided bytes for the individual fields in this
+     * class. This methods also supports partial parsing where not all the bytes
+     * required for parsing the fields successfully are available.
+     *
      * @param b
      *            the byte array to deserialize.
      * @param off
@@ -867,6 +888,16 @@ public class CiphertextHeaders {
      */
     public void setSuiteData(byte[] suiteData) {
         suiteData_ = suiteData.clone();
+    }
+
+    /**
+     * Return max encrypted data keys
+     * Package scope for unit testing.
+     *
+     * @return int
+     */
+    int getMaxEncryptedDataKeys() {
+        return maxEncryptedDataKeys_;
     }
 
     private static class PartialParseException extends Exception {

--- a/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/model/CiphertextHeadersTest.java
@@ -51,6 +51,8 @@ public class CiphertextHeadersTest {
 
     @Test
     public void serializeDeserialize() {
+        int maxEncryptedDataKeys = 42;
+
         Map<String, String> encryptionContext = new HashMap<String, String>(1);
         encryptionContext.put("ENC", "CiphertextHeader Test");
 
@@ -59,9 +61,28 @@ public class CiphertextHeadersTest {
 
             final byte[] headerBytes = ciphertextHeaders.toByteArray();
             final CiphertextHeaders reconstructedHeaders = new CiphertextHeaders();
-            reconstructedHeaders.deserialize(headerBytes, 0, CiphertextHeaders.NO_MAX_ENCRYPTED_DATA_KEYS);
+            reconstructedHeaders.deserialize(headerBytes, 0, maxEncryptedDataKeys);
             final byte[] reconstructedHeaderBytes = reconstructedHeaders.toByteArray();
 
+            assertEquals(reconstructedHeaders.getMaxEncryptedDataKeys(), maxEncryptedDataKeys);
+            assertArrayEquals(headerBytes, reconstructedHeaderBytes);
+        }
+    }
+
+    @Test
+    public void serializeDeserializeDefaultMaxEncryptedDataKeys() {
+        Map<String, String> encryptionContext = new HashMap<String, String>(1);
+        encryptionContext.put("ENC", "CiphertextHeader Test");
+
+        for (CryptoAlgorithm alg : testAlgs) {
+            final CiphertextHeaders ciphertextHeaders = createCiphertextHeaders(encryptionContext, alg);
+
+            final byte[] headerBytes = ciphertextHeaders.toByteArray();
+            final CiphertextHeaders reconstructedHeaders = new CiphertextHeaders();
+            reconstructedHeaders.deserialize(headerBytes, 0);
+            final byte[] reconstructedHeaderBytes = reconstructedHeaders.toByteArray();
+
+            assertEquals(reconstructedHeaders.getMaxEncryptedDataKeys(), CiphertextHeaders.NO_MAX_ENCRYPTED_DATA_KEYS);
             assertArrayEquals(headerBytes, reconstructedHeaderBytes);
         }
     }


### PR DESCRIPTION
*Description of changes:*
Same as https://github.com/aws/aws-encryption-sdk-java/pull/382, porting to `1.x` branch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

