### PR TITLE
chore: update release process with release feedback

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -57,7 +57,7 @@
           }],
           ["@semantic-release/git", {
             "assets": ["./CHANGELOG.md", "./pom.xml", "./README.md"],
-            "message": "AWS Encryption SDK ${nextRelease.version} Release \n\n${nextRelease.notes}"
+            "message": "AWS Encryption SDK ${nextRelease.version} Release -- $(date +%Y-%m-%d) \n\n${nextRelease.notes}"
           }],
     ],
     "repositoryUrl": "https://github.com/aws/aws-encryption-sdk-java",

--- a/.releaserc
+++ b/.releaserc
@@ -53,12 +53,12 @@
           ["@semantic-release/exec", {
             "prepareCmd": "mvn versions:set -DnewVersion=${nextRelease.version} \
                     -DautoVersionSubmodules=true && find README.md -type f \
-                    -exec sed -i '' 's/<version>.*<\\/version>/<version>${nextRelease.version}<\\/version>/g' {} \\;"
+                    -exec sed -i 's/<version>.*<\\/version>/<version>${nextRelease.version}<\\/version>/g' {} \\;"
           }],
           ["@semantic-release/git", {
             "assets": ["./CHANGELOG.md", "./pom.xml", "./README.md"],
             "message": "AWS Encryption SDK ${nextRelease.version} Release \n\n${nextRelease.notes}"
           }],
     ],
-    "repositoryUrl": "https://github.com/aws/aws-encryption-sdk-java",
+    "repositoryUrl": "https://github.com/josecorella/aws-encryption-sdk-java",
 }

--- a/.releaserc
+++ b/.releaserc
@@ -60,5 +60,5 @@
             "message": "AWS Encryption SDK ${nextRelease.version} Release \n\n${nextRelease.notes}"
           }],
     ],
-    "repositoryUrl": "https://github.com/josecorella/aws-encryption-sdk-java",
+    "repositoryUrl": "https://github.com/aws/aws-encryption-sdk-java",
 }

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You can get the latest release from Maven:
 <dependency>
   <groupId>com.amazonaws</groupId>
   <artifactId>aws-encryption-sdk-java</artifactId>
-  <version>1.9.0</version>
+  <version>1.9.1</version>
 </dependency>
 ```
 

--- a/codebuild/release/artifact-hunt.yml
+++ b/codebuild/release/artifact-hunt.yml
@@ -1,0 +1,20 @@
+## Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+env:
+  variables:
+    BRANCH: "mainline-1.x"
+
+phases:
+  install:
+    runtime-versions:
+      java: corretto11
+  pre_build:
+    commands:
+      - git checkout $BRANCH
+      - export VERSION=$(grep version pom.xml | head -n 1 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+  build:
+    commands:
+      - ./look_4_version.sh $VERSION

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -38,4 +38,3 @@ phases:
           -Dsonatype.password="$SONA_PASSWORD" \
           --no-transfer-progress \
           -s $SETTINGS_FILE
-      - ./look_4_version.sh $VERSION

--- a/codebuild/release/release.yml
+++ b/codebuild/release/release.yml
@@ -7,127 +7,127 @@ batch:
   fast-fail: true
   build-graph:
 
-    ## Release to CodeArtifact
-    #  - identifier: release_staging
-    #    buildspec: codebuild/release/release-staging.yml
-    #
-    ## Validate CodeArtifact with supported JDK and Corretto
-    #  - identifier: validate_staging_release_openjdk8
-    #    depend-on:
-    #      - release_staging
-    #    buildspec: codebuild/release/validate-staging.yml
-    #    env:
-    #      variables:
-    #        JAVA_ENV_VERSION: openjdk8
-    #        JAVA_NUMERIC_VERSION: 8
-    #      image: aws/codebuild/standard:3.0
-    #
-    #  - identifier: validate_staging_release_openjdk11
-    #    depend-on:
-    #      - release_staging
-    #    buildspec: codebuild/release/validate-staging.yml
-    #    env:
-    #      variables:
-    #        JAVA_ENV_VERSION: openjdk11
-    #        JAVA_NUMERIC_VERSION: 11
-    #      image: aws/codebuild/standard:3.0
-    #
-    #  - identifier: validate_staging_release_corretto8
-    #    depend-on:
-    #      - release_staging
-    #    buildspec: codebuild/release/validate-staging.yml
-    #    env:
-    #      variables:
-    #        JAVA_ENV_VERSION: corretto8
-    #        JAVA_NUMERIC_VERSION: 8
-    #      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-    #
-    #  - identifier: validate_staging_release_corretto11
-    #    depend-on:
-    #      - release_staging
-    #    buildspec: codebuild/release/validate-staging.yml
-    #    env:
-    #      variables:
-    #        JAVA_ENV_VERSION: corretto11
-    #        JAVA_NUMERIC_VERSION: 11
-    #      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+# Release to CodeArtifact
+  - identifier: release_staging
+    buildspec: codebuild/release/release-staging.yml
+
+# Validate CodeArtifact with supported JDK and Corretto
+  - identifier: validate_staging_release_openjdk8
+    depend-on:
+      - release_staging
+    buildspec: codebuild/release/validate-staging.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: openjdk8
+        JAVA_NUMERIC_VERSION: 8
+      image: aws/codebuild/standard:3.0
+
+  - identifier: validate_staging_release_openjdk11
+    depend-on:
+      - release_staging
+    buildspec: codebuild/release/validate-staging.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: openjdk11
+        JAVA_NUMERIC_VERSION: 11
+      image: aws/codebuild/standard:3.0
+
+  - identifier: validate_staging_release_corretto8
+    depend-on:
+      - release_staging
+    buildspec: codebuild/release/validate-staging.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: corretto8
+        JAVA_NUMERIC_VERSION: 8
+      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+
+  - identifier: validate_staging_release_corretto11
+    depend-on:
+      - release_staging
+    buildspec: codebuild/release/validate-staging.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: corretto11
+        JAVA_NUMERIC_VERSION: 11
+      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
 
 # Version Project
-#  - identifier: version
-#    #depend-on:
-#    #  - release_staging
-#    #  - validate_staging_release_openjdk8
-#    #  - validate_staging_release_openjdk11
-#    #  - validate_staging_release_corretto8
-#    #  - validate_staging_release_corretto11
-#    buildspec: codebuild/release/version.yml
-#    env:
-#      image: aws/codebuild/standard:5.0
-#
-        ## Publish to Maven Central
-        #  - identifier: publish
-        #    depend-on:
-        #      - version
-        #    buildspec: codebuild/release/release-prod.yml
+  - identifier: version
+    depend-on:
+      - release_staging
+      - validate_staging_release_openjdk8
+      - validate_staging_release_openjdk11
+      - validate_staging_release_corretto8
+      - validate_staging_release_corretto11
+    buildspec: codebuild/release/version.yml
+    env:
+      image: aws/codebuild/standard:5.0
+
+# Publish to Maven Central
+  - identifier: publish
+    depend-on:
+      - version
+    buildspec: codebuild/release/release-prod.yml
 
 # Wait for artifacts to be available
   - identifier: availability
-    #depend-on:
-    #  - version
+    depend-on:
+      - version
     buildspec: codebuild/release/artifact-hunt.yml
     env:
       image: aws/codebuild/standard:5.0
 
-        ## Validate Maven Central with supported JDK and Corretto
-        #  - identifier: validate_prod_release_openjdk8
-        #    depend-on:
-        #      - availability
-        #    buildspec: codebuild/release/validate-prod.yml
-        #    env:
-        #      variables:
-        #        JAVA_ENV_VERSION: openjdk8
-        #        JAVA_NUMERIC_VERSION: 8
-        #      image: aws/codebuild/standard:3.0
-        #
-        #  - identifier: validate_prod_release_openjdk11
-        #    depend-on:
-        #      - availability
-        #    buildspec: codebuild/release/validate-prod.yml
-        #    env:
-        #      variables:
-        #        JAVA_ENV_VERSION: openjdk11
-        #        JAVA_NUMERIC_VERSION: 11
-        #      image: aws/codebuild/standard:3.0
-        #
-        #  - identifier: validate_prod_release_corretto8
-        #    depend-on:
-        #      - availability
-        #    buildspec: codebuild/release/validate-prod.yml
-        #    env:
-        #      variables:
-        #        JAVA_ENV_VERSION: corretto8
-        #        JAVA_NUMERIC_VERSION: 8
-        #      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-        #
-        #  - identifier: validate_prod_release_corretto11
-        #    depend-on:
-        #      - availability
-        #    buildspec: codebuild/release/validate-prod.yml
-        #    env:
-        #      variables:
-        #        JAVA_ENV_VERSION: corretto11
-        #        JAVA_NUMERIC_VERSION: 11
-        #      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-        #
-        ## Upload Artifacts
-        #  - identifier: upload_artifacts
-        #    depend-on:
-        #      - validate_prod_release_openjdk8
-        #      - validate_prod_release_openjdk11
-        #      - validate_prod_release_corretto8
-        #      - validate_prod_release_corretto11
-        #    buildspec: codebuild/release/upload_artifacts.yml
-        #    env:
-        #      # Changing to standard:5.0 because we are able to install gh cli on ubuntu but
-        #      # not on AmazonLinux
-        #      image: aws/codebuild/standard:5.0
+# Validate Maven Central with supported JDK and Corretto
+  - identifier: validate_prod_release_openjdk8
+    depend-on:
+      - availability
+    buildspec: codebuild/release/validate-prod.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: openjdk8
+        JAVA_NUMERIC_VERSION: 8
+      image: aws/codebuild/standard:3.0
+
+  - identifier: validate_prod_release_openjdk11
+    depend-on:
+      - availability
+    buildspec: codebuild/release/validate-prod.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: openjdk11
+        JAVA_NUMERIC_VERSION: 11
+      image: aws/codebuild/standard:3.0
+
+  - identifier: validate_prod_release_corretto8
+    depend-on:
+      - availability
+    buildspec: codebuild/release/validate-prod.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: corretto8
+        JAVA_NUMERIC_VERSION: 8
+      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+
+  - identifier: validate_prod_release_corretto11
+    depend-on:
+      - availability
+    buildspec: codebuild/release/validate-prod.yml
+    env:
+      variables:
+        JAVA_ENV_VERSION: corretto11
+        JAVA_NUMERIC_VERSION: 11
+      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+
+# Upload Artifacts
+  - identifier: upload_artifacts
+    depend-on:
+      - validate_prod_release_openjdk8
+      - validate_prod_release_openjdk11
+      - validate_prod_release_corretto8
+      - validate_prod_release_corretto11
+    buildspec: codebuild/release/upload_artifacts.yml
+    env:
+      # Changing to standard:5.0 because we are able to install gh cli on ubuntu but
+      # not on AmazonLinux
+      image: aws/codebuild/standard:5.0

--- a/codebuild/release/release.yml
+++ b/codebuild/release/release.yml
@@ -7,119 +7,127 @@ batch:
   fast-fail: true
   build-graph:
 
-# Release to CodeArtifact
-  - identifier: release_staging
-    buildspec: codebuild/release/release-staging.yml
-
-# Validate CodeArtifact with supported JDK and Corretto
-  - identifier: validate_staging_release_openjdk8
-    depend-on:
-      - release_staging
-    buildspec: codebuild/release/validate-staging.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: openjdk8
-        JAVA_NUMERIC_VERSION: 8
-      image: aws/codebuild/standard:3.0
-
-  - identifier: validate_staging_release_openjdk11
-    depend-on:
-      - release_staging
-    buildspec: codebuild/release/validate-staging.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: openjdk11
-        JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/standard:3.0
-
-  - identifier: validate_staging_release_corretto8
-    depend-on:
-      - release_staging
-    buildspec: codebuild/release/validate-staging.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: corretto8
-        JAVA_NUMERIC_VERSION: 8
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-
-  - identifier: validate_staging_release_corretto11
-    depend-on:
-      - release_staging
-    buildspec: codebuild/release/validate-staging.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: corretto11
-        JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    ## Release to CodeArtifact
+    #  - identifier: release_staging
+    #    buildspec: codebuild/release/release-staging.yml
+    #
+    ## Validate CodeArtifact with supported JDK and Corretto
+    #  - identifier: validate_staging_release_openjdk8
+    #    depend-on:
+    #      - release_staging
+    #    buildspec: codebuild/release/validate-staging.yml
+    #    env:
+    #      variables:
+    #        JAVA_ENV_VERSION: openjdk8
+    #        JAVA_NUMERIC_VERSION: 8
+    #      image: aws/codebuild/standard:3.0
+    #
+    #  - identifier: validate_staging_release_openjdk11
+    #    depend-on:
+    #      - release_staging
+    #    buildspec: codebuild/release/validate-staging.yml
+    #    env:
+    #      variables:
+    #        JAVA_ENV_VERSION: openjdk11
+    #        JAVA_NUMERIC_VERSION: 11
+    #      image: aws/codebuild/standard:3.0
+    #
+    #  - identifier: validate_staging_release_corretto8
+    #    depend-on:
+    #      - release_staging
+    #    buildspec: codebuild/release/validate-staging.yml
+    #    env:
+    #      variables:
+    #        JAVA_ENV_VERSION: corretto8
+    #        JAVA_NUMERIC_VERSION: 8
+    #      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+    #
+    #  - identifier: validate_staging_release_corretto11
+    #    depend-on:
+    #      - release_staging
+    #    buildspec: codebuild/release/validate-staging.yml
+    #    env:
+    #      variables:
+    #        JAVA_ENV_VERSION: corretto11
+    #        JAVA_NUMERIC_VERSION: 11
+    #      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
 
 # Version Project
-  - identifier: version
-    depend-on:
-      - release_staging
-      - validate_staging_release_openjdk8
-      - validate_staging_release_openjdk11
-      - validate_staging_release_corretto8
-      - validate_staging_release_corretto11
-    buildspec: codebuild/release/version.yml
+#  - identifier: version
+#    #depend-on:
+#    #  - release_staging
+#    #  - validate_staging_release_openjdk8
+#    #  - validate_staging_release_openjdk11
+#    #  - validate_staging_release_corretto8
+#    #  - validate_staging_release_corretto11
+#    buildspec: codebuild/release/version.yml
+#    env:
+#      image: aws/codebuild/standard:5.0
+#
+        ## Publish to Maven Central
+        #  - identifier: publish
+        #    depend-on:
+        #      - version
+        #    buildspec: codebuild/release/release-prod.yml
+
+# Wait for artifacts to be available
+  - identifier: availability
+    #depend-on:
+    #  - version
+    buildspec: codebuild/release/artifact-hunt.yml
     env:
       image: aws/codebuild/standard:5.0
 
-# Publish to Maven Central
-  - identifier: publish
-    depend-on:
-      - version
-    buildspec: codebuild/release/release-prod.yml
-
-# Validate Maven Central with supported JDK and Corretto
-  - identifier: validate_prod_release_openjdk8
-    depend-on:
-      - publish
-    buildspec: codebuild/release/validate-prod.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: openjdk8
-        JAVA_NUMERIC_VERSION: 8
-      image: aws/codebuild/standard:3.0
-
-  - identifier: validate_prod_release_openjdk11
-    depend-on:
-      - publish
-    buildspec: codebuild/release/validate-prod.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: openjdk11
-        JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/standard:3.0
-
-  - identifier: validate_prod_release_corretto8
-    depend-on:
-      - publish
-    buildspec: codebuild/release/validate-prod.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: corretto8
-        JAVA_NUMERIC_VERSION: 8
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-
-  - identifier: validate_prod_release_corretto11
-    depend-on:
-      - publish
-    buildspec: codebuild/release/validate-prod.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: corretto11
-        JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
-
-# Upload Artifacts
-  - identifier: upload_artifacts
-    depend-on:
-      - validate_prod_release_openjdk8
-      - validate_prod_release_openjdk11
-      - validate_prod_release_corretto8
-      - validate_prod_release_corretto11
-    buildspec: codebuild/release/upload_artifacts.yml
-    env:
-      # Changing to standard:5.0 because we are able to install gh cli on ubuntu but
-      # not on AmazonLinux
-      image: aws/codebuild/standard:5.0
+        ## Validate Maven Central with supported JDK and Corretto
+        #  - identifier: validate_prod_release_openjdk8
+        #    depend-on:
+        #      - availability
+        #    buildspec: codebuild/release/validate-prod.yml
+        #    env:
+        #      variables:
+        #        JAVA_ENV_VERSION: openjdk8
+        #        JAVA_NUMERIC_VERSION: 8
+        #      image: aws/codebuild/standard:3.0
+        #
+        #  - identifier: validate_prod_release_openjdk11
+        #    depend-on:
+        #      - availability
+        #    buildspec: codebuild/release/validate-prod.yml
+        #    env:
+        #      variables:
+        #        JAVA_ENV_VERSION: openjdk11
+        #        JAVA_NUMERIC_VERSION: 11
+        #      image: aws/codebuild/standard:3.0
+        #
+        #  - identifier: validate_prod_release_corretto8
+        #    depend-on:
+        #      - availability
+        #    buildspec: codebuild/release/validate-prod.yml
+        #    env:
+        #      variables:
+        #        JAVA_ENV_VERSION: corretto8
+        #        JAVA_NUMERIC_VERSION: 8
+        #      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        #
+        #  - identifier: validate_prod_release_corretto11
+        #    depend-on:
+        #      - availability
+        #    buildspec: codebuild/release/validate-prod.yml
+        #    env:
+        #      variables:
+        #        JAVA_ENV_VERSION: corretto11
+        #        JAVA_NUMERIC_VERSION: 11
+        #      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+        #
+        ## Upload Artifacts
+        #  - identifier: upload_artifacts
+        #    depend-on:
+        #      - validate_prod_release_openjdk8
+        #      - validate_prod_release_openjdk11
+        #      - validate_prod_release_corretto8
+        #      - validate_prod_release_corretto11
+        #    buildspec: codebuild/release/upload_artifacts.yml
+        #    env:
+        #      # Changing to standard:5.0 because we are able to install gh cli on ubuntu but
+        #      # not on AmazonLinux
+        #      image: aws/codebuild/standard:5.0

--- a/codebuild/release/upload_artifacts.yml
+++ b/codebuild/release/upload_artifacts.yml
@@ -5,26 +5,31 @@ version: 0.2
 
 env:
   variables:
-    BRANCH: "mainline-1.x"
+    BRANCH: "master"
   git-credential-helper: yes
   secrets-manager:
-    GH_TOKEN: Github/aws-crypto-tools-ci-bot:personal\ access\ token
+    GH_TOKEN: Github/aws-crypto-tools-ci-bot:ESDK Release Token
 
 phases:
   pre_build:
     commands:
-      - git checkout $BRANCH
         # get new project version
       - export VERSION=$(grep version pom.xml | head -n 1 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+      - git config --global user.name "aws-crypto-tools-ci-bot"
+      - git config --global user.email "no-reply@noemail.local"
+      - echo $GH_TOKEN > token.txt
+      - export GH_TOKEN=
         # install gh cli in order to upload artifacts
       - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
       - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
       - apt update
       - apt install gh
+      - git checkout $BRANCH
   build:
     commands:
       - gh version
-      - gh auth login --with-token < $GH_TOKEN
+      - gh auth login --with-token < token.txt
+      - gh auth status
       - |
         mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
           -DrepoUrl=https://aws.oss.sonatype.org \
@@ -37,4 +42,4 @@ phases:
         mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
           -DrepoUrl=https://aws.oss.sonatype.org \
           -Dartifact=com.amazonaws:aws-encryption-sdk-java:${VERSION}:jar:javadoc
-      - gh release create v${VERSION}  ~/.m2/repository/com/amazonaws/aws-encryption-sdk-java/${VERSION}/*.jar -d -F CHANGELOG.md -t "AWS Encryption SDK ${VERSION} Release -- $(date +%Y-%m-%d)"
+      - gh release create v${VERSION} ~/.m2/repository/com/amazonaws/aws-encryption-sdk-java/${VERSION}/*.jar -d -F CHANGELOG.md -t "AWS Encryption SDK ${VERSION} Release -- $(date +%Y-%m-%d)"

--- a/codebuild/release/upload_artifacts.yml
+++ b/codebuild/release/upload_artifacts.yml
@@ -37,4 +37,4 @@ phases:
         mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
           -DrepoUrl=https://aws.oss.sonatype.org \
           -Dartifact=com.amazonaws:aws-encryption-sdk-java:${VERSION}:jar:javadoc
-      - gh release upload v${VERSION} ~/.m2/repository/com/amazonaws/aws-encryption-sdk-java/${VERSION}/*.jar
+      - gh release create v${VERSION}  ~/.m2/repository/com/amazonaws/aws-encryption-sdk-java/${VERSION}/*.jar -d -F CHANGELOG.md -t "AWS Encryption SDK ${VERSION} Release -- ${date '%y-%m-%d'}"

--- a/codebuild/release/upload_artifacts.yml
+++ b/codebuild/release/upload_artifacts.yml
@@ -37,4 +37,4 @@ phases:
         mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
           -DrepoUrl=https://aws.oss.sonatype.org \
           -Dartifact=com.amazonaws:aws-encryption-sdk-java:${VERSION}:jar:javadoc
-      - gh release create v${VERSION}  ~/.m2/repository/com/amazonaws/aws-encryption-sdk-java/${VERSION}/*.jar -d -F CHANGELOG.md -t "AWS Encryption SDK ${VERSION} Release -- ${date '%y-%m-%d'}"
+      - gh release create v${VERSION}  ~/.m2/repository/com/amazonaws/aws-encryption-sdk-java/${VERSION}/*.jar -d -F CHANGELOG.md -t "AWS Encryption SDK ${VERSION} Release -- $(date +%Y-%m-%d)"

--- a/codebuild/release/version.yml
+++ b/codebuild/release/version.yml
@@ -26,5 +26,8 @@ phases:
       - git checkout $BRANCH
   build:
     commands:
-     - npx semantic-release --branches $BRANCH --no-ci
+      - ls
+      - find README.md
+      - cat README.md
+      - npx semantic-release --branches $BRANCH --no-ci
  

--- a/codebuild/release/version.yml
+++ b/codebuild/release/version.yml
@@ -26,8 +26,5 @@ phases:
       - git checkout $BRANCH
   build:
     commands:
-      - ls
-      - find README.md
-      - cat README.md
       - npx semantic-release --branches $BRANCH --no-ci
  


### PR DESCRIPTION
*Description of changes:*
This PR breaks up the release-prod build into two. 
1. Release to maven central
2. wait for artifact to appear

This will help us if it takes too long for the artifacts to appear we can just restart the looking for new version build instead of trying to publish again which with the release of 1.9.1 we found out will fail the build.

This PR also updates the upload artifact command to create the release using the github cli

NOTE: once this PR gets merged in these changes will get ported over to the `master` branch via cherry pick

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

