### PR TITLE
feat: Add decrypt verification step after encryption

### DIFF
--- a/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoTest.java
@@ -1341,4 +1341,11 @@ public class AwsCryptoTest {
     IOUtils.copy(new ByteArrayInputStream(ciphertext), decryptStream);
     decryptStream.close();
   }
+
+  @Test
+  public void setDecryptionCheck() {
+    assertFalse(encryptionClient_.getDecryptionCheckOnEncrypt());
+    encryptionClient_.setDecryptionCheckOnEncrypt(true);
+    assertTrue(encryptionClient_.getDecryptionCheckOnEncrypt());
+  }
 }


### PR DESCRIPTION
Issue #279 

Description of changes:

Adds a boolean which when set to true would enable decryption verification step after messages successfully encrypted. This avoids needing to implement this outside of this library to ensure encrypted messages can successfully be decrypted without any corruption or issues.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

