### PR TITLE
chore: update token name and timeout

### DIFF
--- a/codebuild/release/upload_artifacts.yml
+++ b/codebuild/release/upload_artifacts.yml
@@ -8,7 +8,7 @@ env:
     BRANCH: "master"
   git-credential-helper: yes
   secrets-manager:
-    GH_TOKEN: Github/aws-crypto-tools-ci-bot:personal\ access\ token
+    GH_TOKEN: Github/aws-crypto-tools-ci-bot:personal\ access\ token\ (new\ token\ format)
 
 phases:
   pre_build:

--- a/look_4_version.sh
+++ b/look_4_version.sh
@@ -19,7 +19,7 @@ while [  $STATUS -ne 0 ]; do
         break
     fi
 
-    if [  $((COUNTER+=1)) -eq 10 ]; then
+    if [  $((COUNTER+=1)) -eq 15 ]; then
         echo "It has been an awfully long time, you should check Maven Central for issues"
         exit 1
     fi


### PR DESCRIPTION
*Description of changes:*
In prep for v2.3.4 release this PR increases the search timeout and uses the correct gh token

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

