### PR TITLE
chore: update gh token

### DIFF
--- a/codebuild/release/upload_artifacts.yml
+++ b/codebuild/release/upload_artifacts.yml
@@ -8,13 +8,17 @@ env:
     BRANCH: "master"
   git-credential-helper: yes
   secrets-manager:
-    GH_TOKEN: Github/aws-crypto-tools-ci-bot:personal\ access\ token\ (new\ token\ format)
+    GH_TOKEN: Github/aws-crypto-tools-ci-bot:ESDK Release Token
 
 phases:
   pre_build:
     commands:
         # get new project version
       - export VERSION=$(grep version pom.xml | head -n 1 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+      - git config --global user.name "aws-crypto-tools-ci-bot"
+      - git config --global user.email "no-reply@noemail.local"
+      - echo $GH_TOKEN > token.txt
+      - export GH_TOKEN=
         # install gh cli in order to upload artifacts
       - curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg
       - echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
@@ -24,7 +28,8 @@ phases:
   build:
     commands:
       - gh version
-      - gh auth login --with-token < $GH_TOKEN
+      - gh auth login --with-token < token.txt
+      - gh auth status
       - |
         mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
           -DrepoUrl=https://aws.oss.sonatype.org \


### PR DESCRIPTION
*Description of changes:*
Uses the correct GH PAT in order to log in to github using the gh cli. gh cli is needed in order to create the release and upload the artifacts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

