### PR TITLE
fix(ci): Quote commit statement to prevent errant YAML parsing

### DIFF
--- a/codebuild/release/javadoc.yml
+++ b/codebuild/release/javadoc.yml
@@ -22,5 +22,5 @@ phases:
       - git checkout $GH_PAGES
       - cp -r /tmp/apidocs/* .
       - git add .
-      - git commit -m "docs: updating javadocs"
+      - 'git commit -m "docs: updating javadocs"'
       - git push


### PR DESCRIPTION
*Description of changes:*
YAML tries to parse the colon within a quoted string and causes the last step of the build to fail. Quoting the entire string prevents this condition

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

