### PR TITLE
feat: Add getters for commitment policy and max EDK count

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -234,6 +234,10 @@ public class AwsCrypto {
     return encryptionAlgorithm_;
   }
 
+  public CommitmentPolicy getCommitmentPolicy() { return commitmentPolicy_; }
+
+  public int getMaxEncryptedDataKeys() { return maxEncryptedDataKeys_; }
+
   /**
    * Sets the framing size to use when <em>encrypting</em> data. This has no impact on decryption.
    * If {@code frameSize} is 0, then framing is disabled and the entire plaintext will be encrypted


### PR DESCRIPTION
*Description of changes:*
Using the ESDK as a transitive dependency is difficult without being able to safely check for parameters and compatibility _i.e._ commitment policy and the algorithm used without trying and catching exceptions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

