### PR TITLE
docs: Detail AWS SDK v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use the AWS Encryption SDK for Java you must have:
 ### Optional Prerequisites
 
 #### AWS Integration
-    You don't need an Amazon Web Services (AWS) account to use the AWS Encryption SDK, but some [example code][examples] require an AWS account, an AWS KMS key, and the AWS SDK for Java (either 1.x or 2.x). Note that the `KmsAsyncClient` is not supported, only the regular synchronous client.
+You don't need an Amazon Web Services (AWS) account to use the AWS Encryption SDK, but some [example code][examples] require an AWS account, an AWS KMS key, and the AWS SDK for Java (either 1.x or 2.x). Note that the `KmsAsyncClient` is not supported, only the regular synchronous client.
 
 * **To create an AWS account**, go to [Sign In or Create an AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) and then choose **I am a new user.** Follow the instructions to create an AWS account.
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use the AWS Encryption SDK for Java you must have:
 ### Optional Prerequisites
 
 #### AWS Integration
-You don't need an Amazon Web Services (AWS) account to use the AWS Encryption SDK, but some [example code][examples] require an AWS account, an AWS KMS key, and the AWS SDK for Java (either 1.x or 2.x).
+    You don't need an Amazon Web Services (AWS) account to use the AWS Encryption SDK, but some [example code][examples] require an AWS account, an AWS KMS key, and the AWS SDK for Java (either 1.x or 2.x). Note that the `KmsAsyncClient` is not supported, only the regular synchronous client.
 
 * **To create an AWS account**, go to [Sign In or Create an AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) and then choose **I am a new user.** Follow the instructions to create an AWS account.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more details about the design and architecture of the AWS Encryption SDK, se
 
 [Security issue notifications](./CONTRIBUTING.md#security-issue-notifications)
 
-See [Support Policy](./SUPPORT_POLICY.rst) for for details on the current support status of all major versions of this library.
+See [Support Policy](./SUPPORT_POLICY.rst) for details on the current support status of all major versions of this library.
 
 ## Getting Started
 
@@ -37,11 +37,13 @@ To use the AWS Encryption SDK for Java you must have:
 ### Optional Prerequisites
 
 #### AWS Integration
-You don't need an Amazon Web Services (AWS) account to use the AWS Encryption SDK, but some of the [example code][examples] require an AWS account, an AWS KMS key, and the AWS SDK for Java 1.x. (The AWS Encryption SDK for Java does not support the AWS SDK for Java 2.x.)
+You don't need an Amazon Web Services (AWS) account to use the AWS Encryption SDK, but some [example code][examples] require an AWS account, an AWS KMS key, and the AWS SDK for Java (either 1.x or 2.x).
 
 * **To create an AWS account**, go to [Sign In or Create an AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) and then choose **I am a new user.** Follow the instructions to create an AWS account.
 
 * **To create a symmetric encryption KMS key in AWS KMS**, see [Creating Keys](https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html).
+
+* **To download and install the AWS SDK for Java 2.x**, see [Installing the AWS SDK for Java 2.x](https://docs.aws.amazon.com/sdk-for-java/v2/developer-guide/getting-started.html).
 
 * **To download and install the AWS SDK for Java 1.x**, see [Installing the AWS SDK for Java 1.x](https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/getting-started.html).
 
@@ -133,7 +135,7 @@ public class StringExample {
 }
 ```
 
-You can find more examples in the [examples directory][examples].
+You can find more examples in the [example directory][examples].
 
 ## Public API
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To use the AWS Encryption SDK for Java you must have:
 ### Optional Prerequisites
 
 #### AWS Integration
-You don't need an Amazon Web Services (AWS) account to use the AWS Encryption SDK, but some [example code][examples] require an AWS account, an AWS KMS key, and the AWS SDK for Java (either 1.x or 2.x). Note that the `KmsAsyncClient` is not supported, only the regular synchronous client.
+You don't need an Amazon Web Services (AWS) account to use the AWS Encryption SDK, but some [example code][examples] require an AWS account, an AWS KMS key, and the AWS SDK for Java (either 1.x or 2.x). Note that the `KmsAsyncClient` is not supported, only the synchronous client.
 
 * **To create an AWS account**, go to [Sign In or Create an AWS Account](https://portal.aws.amazon.com/gp/aws/developer/registration/index.html) and then choose **I am a new user.** Follow the instructions to create an AWS account.
 

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
@@ -107,9 +107,10 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * <p>Because the regional client supplier fully controls the client construction process, it is
      * not possible to configure the client through methods such as {@link
      * #builderSupplier(Supplier)}; if you try to use these in combination, an {@link
-     * IllegalStateException} will be thrown.</p>
+     * IllegalStateException} will be thrown.
      *
-     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
+     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient}
+     * interface.
      *
      * @see KmsMasterKeyProvider.Builder#customRegionalClientSupplier(RegionalClientSupplier)
      */
@@ -127,7 +128,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * KmsClientBuilder} to configure KMS clients. Note that the region set on this builder will be
      * ignored, but all other settings will be propagated into the regional clients.
      *
-     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
+     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient}
+     * interface.
      *
      * @see KmsMasterKeyProvider.Builder#builderSupplier(Supplier)
      */

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
@@ -107,7 +107,9 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * <p>Because the regional client supplier fully controls the client construction process, it is
      * not possible to configure the client through methods such as {@link
      * #builderSupplier(Supplier)}; if you try to use these in combination, an {@link
-     * IllegalStateException} will be thrown.
+     * IllegalStateException} will be thrown.</p>
+     *
+     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
      *
      * @see KmsMasterKeyProvider.Builder#customRegionalClientSupplier(RegionalClientSupplier)
      */
@@ -124,6 +126,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * Configures the {@link AwsKmsMrkAwareMasterKeyProvider} to use settings from this {@link
      * KmsClientBuilder} to configure KMS clients. Note that the region set on this builder will be
      * ignored, but all other settings will be propagated into the regional clients.
+     *
+     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
      *
      * @see KmsMasterKeyProvider.Builder#builderSupplier(Supplier)
      */

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/KmsMasterKeyProvider.java
@@ -87,7 +87,9 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
      * <p>Because the regional client supplier fully controls the client construction process, it is
      * not possible to configure the client through methods such as {@link
      * #builderSupplier(Supplier)}; if you try to use these in combination, an {@link
-     * IllegalStateException} will be thrown.
+     * IllegalStateException} will be thrown.</p>
+     *
+     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
      *
      * @param regionalClientSupplier
      * @return
@@ -108,7 +110,9 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
      *
      * <p>Trying to use this method in combination with {@link
      * #customRegionalClientSupplier(RegionalClientSupplier)} will cause an {@link
-     * IllegalStateException} to be thrown.
+     * IllegalStateException} to be thrown.</p>
+     *
+     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
      *
      * @param supplier Should return a new {@link KmsClientBuilder} on each invocation.
      * @return

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/KmsMasterKeyProvider.java
@@ -87,9 +87,10 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
      * <p>Because the regional client supplier fully controls the client construction process, it is
      * not possible to configure the client through methods such as {@link
      * #builderSupplier(Supplier)}; if you try to use these in combination, an {@link
-     * IllegalStateException} will be thrown.</p>
+     * IllegalStateException} will be thrown.
      *
-     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
+     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient}
+     * interface.
      *
      * @param regionalClientSupplier
      * @return
@@ -110,9 +111,10 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
      *
      * <p>Trying to use this method in combination with {@link
      * #customRegionalClientSupplier(RegionalClientSupplier)} will cause an {@link
-     * IllegalStateException} to be thrown.</p>
+     * IllegalStateException} to be thrown.
      *
-     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
+     * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient}
+     * interface.
      *
      * @param supplier Should return a new {@link KmsClientBuilder} on each invocation.
      * @return

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/RegionalClientSupplier.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/RegionalClientSupplier.java
@@ -9,7 +9,7 @@ public interface RegionalClientSupplier {
    * Supplies an {@link KmsClient} instance to use for a given {@link Region}. The {@link
    * KmsMasterKeyProvider} will not cache the result of this function.
    *
-   * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
+   * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.
    *
    * @param region The region to get a client for
    * @return The client to use, or null if this region cannot or should not be used.

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/RegionalClientSupplier.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/RegionalClientSupplier.java
@@ -9,6 +9,8 @@ public interface RegionalClientSupplier {
    * Supplies an {@link KmsClient} instance to use for a given {@link Region}. The {@link
    * KmsMasterKeyProvider} will not cache the result of this function.
    *
+   * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient} interface.</p>
+   *
    * @param region The region to get a client for
    * @return The client to use, or null if this region cannot or should not be used.
    */


### PR DESCRIPTION
*Issue #, if available:* #834, #829

*Description of changes:*
Corrects the README to state AWS SDK for Java 2.x support.

Updates the JavaDocs for classes that use `KmsClient` interface
to state the `KmsAsyncClient` is not supported.

Closes #834 .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

