### PR TITLE
chore: use new signing keys for ci

### DIFF
--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -22,7 +22,8 @@ phases:
       - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
-      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-CI-Keys --query SecretBinary --output text | base64 -d > $HOME/mvn_gpg
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-CI-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:
       - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION"

--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -22,7 +22,7 @@ phases:
       - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
-      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-CI-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys-CI --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
       - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:

--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -24,6 +24,7 @@ phases:
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys-CI --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
       - tar -xvf ~/mvn_gpg.tgz -C ~
+      - gpg --version
   build:
     commands:
       - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION"

--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -10,8 +10,8 @@ env:
   parameter-store:
     ACCOUNT: /CodeBuild/AccountIdentity
   secrets-manager:
-    GPG_KEY: Maven-GPG-Keys-Credentials:Keyname
-    GPG_PASS: Maven-GPG-Keys-Credentials:Passphrase
+    GPG_KEY: Maven-GPG-Keys-CI-Credentials:Keyname
+    GPG_PASS: Maven-GPG-Keys-CI-Credentials:Passphrase
 
 phases:
   install:
@@ -22,8 +22,7 @@ phases:
       - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
-      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
-      - tar -xvf ~/mvn_gpg.tgz -C ~
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-CI-Keys --query SecretBinary --output text | base64 -d > $HOME/mvn_gpg
   build:
     commands:
       - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION"

--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -24,7 +24,6 @@ phases:
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
       - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys-CI --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
       - tar -xvf ~/mvn_gpg.tgz -C ~
-      - gpg --version
   build:
     commands:
       - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION"


### PR DESCRIPTION
*Description of changes:*
This PR updates CI to use a different Signing Key that is only used to sign artifacts that get uploaded to CodeArtifact.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

