### PR TITLE
chore: use correct signing key for release

### DIFF
--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -7,8 +7,8 @@ env:
   variables:
     BRANCH: "master"
   secrets-manager:
-    GPG_KEY: Maven-GPG-Keys-Credentials:Keyname
-    GPG_PASS: Maven-GPG-Keys-Credentials:Passphrase
+    GPG_KEY: Maven-GPG-Keys-Release-Credentials:Keyname
+    GPG_PASS: Maven-GPG-Keys-Release-Credentials:Passphrase
     SONA_USERNAME: Sonatype-Team-Account:Username 
     SONA_PASSWORD: Sonatype-Team-Account:Password
 
@@ -20,7 +20,7 @@ phases:
     commands:
       - git checkout $BRANCH
       - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
-      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys-Release --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
       - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:

--- a/codebuild/release/release-staging.yml
+++ b/codebuild/release/release-staging.yml
@@ -11,8 +11,8 @@ env:
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
   secrets-manager:
-    GPG_KEY: Maven-GPG-Keys-Credentials:Keyname
-    GPG_PASS: Maven-GPG-Keys-Credentials:Passphrase
+    GPG_KEY: Maven-GPG-Keys-Release-Credentials:Keyname
+    GPG_PASS: Maven-GPG-Keys-Release-Credentials:Passphrase
 
 phases:
   install:
@@ -23,7 +23,7 @@ phases:
       - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
       - export CODEARTIFACT_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       - export CODEARTIFACT_REPO_URL=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY}
-      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys-Release --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
       - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:


### PR DESCRIPTION
*Description of changes:*
Uses the new signing gpg signing key for release. This key cannot be accessed through CI, since the service role attached to the CI project does not have access to the keys. This secret can only be accessed with appropriate Admin access. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

