### PR TITLE
chore: Mark 1.x as End-of-Support

### DIFF
--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -1,0 +1,33 @@
+Overview
+========
+This page describes the support policy for the AWS Encryption SDK. We regularly provide the AWS Encryption SDK with updates that may contain support for new or updated APIs, new features, enhancements, bug fixes, security patches, or documentation updates. Updates may also address changes with dependencies, language runtimes, and operating systems.
+
+We recommend users to stay up-to-date with Encryption SDK releases to keep up with the latest features, security updates, and underlying dependencies. Continued use of an unsupported SDK version is not recommended and is done at the user’s discretion
+
+
+Major Version Lifecycle
+========================
+The AWS Encryption SDK follows the same major version lifecycle as the AWS SDK. For details on this lifecycle, see  `AWS SDKs and Tools Maintenance Policy`_.
+
+Version Support Matrix
+======================
+This table describes the current support status of each major version of the AWS Encryption SDK for Java. It also shows the next status each major version will transition to, and the date at which that transition will happen.
+
+.. list-table::
+    :widths: 30 50 50 50
+    :header-rows: 1
+
+    * - Major version
+      - Current status
+      - Next status
+      - Next status date
+    * - 1.x
+      - End of Support
+      -
+      -
+    * - 2.x
+      - Generally Available
+      -
+      -
+
+.. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle

--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -13,8 +13,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.logging.Logger;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * Provides the primary entry-point to the AWS Encryption SDK. All encryption and decryption
@@ -87,10 +87,9 @@ public class AwsCrypto {
 
   private static void warn_end_of_support() {
     LOGGER.warning(
-            "This major version (1.x) of the AWS Encryption SDK for Java has reached End-of-Support.\n" +
-                    "It will no longer receive security updates or bug fixes.\n" +
-                    "Consider updating to the latest version of the AWS Encryption SDK."
-    );
+        "This major version (1.x) of the AWS Encryption SDK for Java has reached End-of-Support.\n"
+            + "It will no longer receive security updates or bug fixes.\n"
+            + "Consider updating to the latest version of the AWS Encryption SDK.");
   }
 
   /**

--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -85,6 +85,14 @@ public class AwsCrypto {
    */
   private final int maxEncryptedDataKeys_;
 
+  private static void warn_end_of_support() {
+    LOGGER.warning(
+            "This major version (1.x) of the AWS Encryption SDK for Java has reached End-of-Support.\n" +
+                    "It will no longer receive security updates or bug fixes.\n" +
+                    "Consider updating to the latest version of the AWS Encryption SDK."
+    );
+  }
+
   /**
    * @deprecated This constructor implicitly configures the Aws Crypto client with a commitment
    *     policy that allows reading encrypted messages without commitment values. Use {@link
@@ -93,16 +101,13 @@ public class AwsCrypto {
    */
   @Deprecated
   public AwsCrypto() {
+    warn_end_of_support();
     commitmentPolicy_ = CommitmentPolicy.ForbidEncryptAllowDecrypt;
     maxEncryptedDataKeys_ = CiphertextHeaders.NO_MAX_ENCRYPTED_DATA_KEYS;
-    LOGGER.warning(
-            "This major version (1.x) of the AWS Encryption SDK for Java has reached End-of-Support.\n" +
-            "It will no longer receive security updates or bug fixes.\n" +
-            "Consider updating to the latest version of the AWS Encryption SDK."
-    );
   }
 
   private AwsCrypto(Builder builder) {
+    warn_end_of_support();
     if (builder.commitmentPolicy_ == null) {
       throw new IllegalArgumentException("Must specify a commitment policy on the client.");
     }

--- a/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/AwsCrypto.java
@@ -13,6 +13,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import java.util.logging.Logger;
 import java.util.Map;
 
 /**
@@ -65,6 +66,7 @@ import java.util.Map;
  */
 @SuppressWarnings("WeakerAccess") // this is a public API
 public class AwsCrypto {
+  private static final Logger LOGGER = Logger.getLogger(AwsCrypto.class.getName());
   private static final Map<String, String> EMPTY_MAP = Collections.emptyMap();
 
   // These are volatile because we allow unsynchronized writes via our setters,
@@ -93,6 +95,11 @@ public class AwsCrypto {
   public AwsCrypto() {
     commitmentPolicy_ = CommitmentPolicy.ForbidEncryptAllowDecrypt;
     maxEncryptedDataKeys_ = CiphertextHeaders.NO_MAX_ENCRYPTED_DATA_KEYS;
+    LOGGER.warning(
+            "This major version (1.x) of the AWS Encryption SDK for Java has reached End-of-Support.\n" +
+            "It will no longer receive security updates or bug fixes.\n" +
+            "Consider updating to the latest version of the AWS Encryption SDK."
+    );
   }
 
   private AwsCrypto(Builder builder) {


### PR DESCRIPTION
*Issue #, if available:* Mark 1.x as End-of-Support

*Description of changes:*
- Client (AwsCrypto) emits a log warning on creation detailing 1.x is in End-of-Support
- Added the support policy from master
- updated the support policy from master to mark 1.x as End-of-Support.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

