### PR TITLE
fix: Fix errors in the example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,12 +122,12 @@ public class StringExample {
 
         // The AWS Encryption SDK may add information to the encryption context, so check to
         // ensure all of the values that you specified when encrypting are *included* in the returned encryption context.
-        if (!context.entrySet().stream
+        if (!context.entrySet().stream()
             .allMatch( e -> e.getValue().equals(decryptResult.getEncryptionContext().get(e.getKey())))) {
                 throw new IllegalStateException("Wrong Encryption Context!");
         }
 
-        assert Arrays.equals(decryptResult.getResult(), data.getBytes(StandardCharsets.UTF_8));
+        assert Arrays.equals(decryptResult.getResult(), plaintext.getBytes(StandardCharsets.UTF_8));
 
         // The data is correct, so return it. 
         System.out.println("Decrypted: " + new String(decryptResult.getResult(), StandardCharsets.UTF_8));


### PR DESCRIPTION
There are two small errors in the example that cause compile errors:
- `.stream` instead of `.stream()`
- `data.getBytes` instead of `plaintext.getBytes`

repro of #1305

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

