### PR TITLE
chore: Use Github environment for CI secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   staticAnalysis:
     name: Static Analysis
+    environment: ci
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -30,6 +31,7 @@ jobs:
           image-override: aws/codebuild/amazonlinux2-x86_64-standard:3.0
   vectorTests:
     name: Vector Tests
+    environment: ci
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
@@ -60,6 +62,7 @@ jobs:
           JAVA_ENV_VERSION: ${{ matrix.platform.distribution }}${{ matrix.version }}
   releaseCI:
     name: Release CI
+    environment: ci
     runs-on: ubuntu-latest
     steps:
       - name: Configure AWS Credentials
@@ -78,6 +81,7 @@ jobs:
           image-override: aws/codebuild/standard:3.0
   validateCI:
     name: Validate CI
+    environment: ci
     runs-on: ubuntu-latest
     needs: releaseCI
     strategy:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

* Add config for CI jobs to use the `ci` Github environment to access secrets.

Once this change is merged, I would validate it by opening a no-op PR from my fork.

This change has 2 assumptions: 1) Environment secrets are passed to fork-origin PRs (may need to add environment approver to `ci` environment); 2) The GHA workflow for a fork-origin PR will be authenticated as the main repo. If either of these are false, this change probably won't work. If that happens, we can revert the change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

