### PR TITLE
chore: fix release-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,9 @@ jobs:
           buildspec-override: codebuild/ci/release-ci.yml
           compute-type-override: BUILD_GENERAL1_LARGE
           image-override: aws/codebuild/standard:3.0
-          env-vars-for-codebuild: GITHUB_REF_NAME
+          env-vars-for-codebuild: GITHUB_EVENT_NAME
         env:
-          GITHUB_REF_NAME: $GITHUB_REF_NAME
+          GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME
   validateCI:
     name: Validate CI
     runs-on: ubuntu-latest
@@ -110,8 +110,8 @@ jobs:
           env-vars-for-codebuild: |
             JAVA_ENV_VERSION,
             JAVA_NUMERIC_VERSION,
-            GITHUB_REF_NAME
+            GITHUB_EVENT_NAME
         env:
           JAVA_ENV_VERSION: ${{ matrix.platform.distribution }}${{ matrix.version }}
           JAVA_NUMERIC_VERSION: ${{ matrix.version }}
-          GITHUB_REF_NAME: $GITHUB_REF_NAME
+          GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,9 @@ jobs:
           buildspec-override: codebuild/ci/release-ci.yml
           compute-type-override: BUILD_GENERAL1_LARGE
           image-override: aws/codebuild/standard:3.0
+          env-vars-for-codebuild: GITHUB_REF_NAME
+        env:
+          GITHUB_REF_NAME: $GITHUB_REF_NAME
   validateCI:
     name: Validate CI
     runs-on: ubuntu-latest
@@ -106,7 +109,9 @@ jobs:
           image-override: ${{ matrix.platform.image }}
           env-vars-for-codebuild: |
             JAVA_ENV_VERSION,
-            JAVA_NUMERIC_VERSION
+            JAVA_NUMERIC_VERSION,
+            GITHUB_REF_NAME
         env:
           JAVA_ENV_VERSION: ${{ matrix.platform.distribution }}${{ matrix.version }}
           JAVA_NUMERIC_VERSION: ${{ matrix.version }}
+          GITHUB_REF_NAME: $GITHUB_REF_NAME

--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -26,7 +26,7 @@ phases:
       - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:
-      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION"
+      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$CODEBUILD_WEBHOOK_TRIGGER"
 
       # Remove any old artifacts with the same commit ID. This allows CI to run more than once for the same commit
       - |

--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -26,7 +26,7 @@ phases:
       - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:
-      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$GITHUB_REF_NAME"
+      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$GITHUB_EVENT_NAME"
 
       # Remove any old artifacts with the same commit ID. This allows CI to run more than once for the same commit
       - |

--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -26,7 +26,7 @@ phases:
       - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:
-      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$CODEBUILD_WEBHOOK_TRIGGER"
+      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-${CODEBUILD_WEBHOOK_TRIGGER}"
 
       # Remove any old artifacts with the same commit ID. This allows CI to run more than once for the same commit
       - |

--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -26,7 +26,7 @@ phases:
       - tar -xvf ~/mvn_gpg.tgz -C ~
   build:
     commands:
-      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-${CODEBUILD_WEBHOOK_TRIGGER}"
+      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$GITHUB_REF_NAME"
 
       # Remove any old artifacts with the same commit ID. This allows CI to run more than once for the same commit
       - |

--- a/codebuild/ci/validate-ci.yml
+++ b/codebuild/ci/validate-ci.yml
@@ -16,7 +16,7 @@ phases:
       java: $JAVA_ENV_VERSION
   pre_build:
     commands:
-      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-${CODEBUILD_WEBHOOK_TRIGGER}"
+      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$GITHUB_REF_NAME"
       - export SETTINGS_FILE=$(pwd)/codebuild/ci/settings.xml
       - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
       - cd busy-engineers-document-bucket/exercises/java/encryption-context-complete

--- a/codebuild/ci/validate-ci.yml
+++ b/codebuild/ci/validate-ci.yml
@@ -16,7 +16,7 @@ phases:
       java: $JAVA_ENV_VERSION
   pre_build:
     commands:
-      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION"
+      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$CODEBUILD_WEBHOOK_TRIGGER"
       - export SETTINGS_FILE=$(pwd)/codebuild/ci/settings.xml
       - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
       - cd busy-engineers-document-bucket/exercises/java/encryption-context-complete

--- a/codebuild/ci/validate-ci.yml
+++ b/codebuild/ci/validate-ci.yml
@@ -16,7 +16,7 @@ phases:
       java: $JAVA_ENV_VERSION
   pre_build:
     commands:
-      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$CODEBUILD_WEBHOOK_TRIGGER"
+      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-${CODEBUILD_WEBHOOK_TRIGGER}"
       - export SETTINGS_FILE=$(pwd)/codebuild/ci/settings.xml
       - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
       - cd busy-engineers-document-bucket/exercises/java/encryption-context-complete

--- a/codebuild/ci/validate-ci.yml
+++ b/codebuild/ci/validate-ci.yml
@@ -16,7 +16,7 @@ phases:
       java: $JAVA_ENV_VERSION
   pre_build:
     commands:
-      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$GITHUB_REF_NAME"
+      - VERSION_HASH="$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)-$CODEBUILD_RESOLVED_SOURCE_VERSION-$GITHUB_EVENT_NAME"
       - export SETTINGS_FILE=$(pwd)/codebuild/ci/settings.xml
       - git clone https://github.com/aws-samples/busy-engineers-document-bucket.git
       - cd busy-engineers-document-bucket/exercises/java/encryption-context-complete


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- To fix CI, where one of the [Release CI builds is failing](https://github.com/aws/aws-encryption-sdk-java/actions/runs/7082549171/job/19273467501#step:3:240).
- Distinguish between builds triggered by `pull_request` or `push`. Update `release-ci.yml` to not delete CA released while both builds triggered at same time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

