### PR TITLE
fix: resolve defaultRegion only if necessary

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
@@ -194,7 +194,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
     public AwsKmsMrkAwareMasterKeyProvider buildDiscovery() {
       final boolean isDiscovery = true;
       if (discoveryMrkRegion_ == null) {
-        // The AWS SDK has a default process for evaluating the default Region. This returns null if no
+        // The AWS SDK has a default process for evaluating the default Region. This returns null if
+        // no
         // default region is found. Because a default region _may_ not be needed.
         // Note: Final Null check is at
         // com.amazonaws.encryptionsdk.kms.AwsKmsMrkAwareMasterKeyProvider#AwsKmsMrkAwareMasterKeyProvider#L417
@@ -203,9 +204,12 @@ public final class AwsKmsMrkAwareMasterKeyProvider
           // # In
           // # discovery mode if a default MRK Region is not configured the AWS SDK
           // # Default Region MUST be used.
-          discoveryMrkRegion_ = new com.amazonaws.regions.DefaultAwsRegionProviderChain().getRegion();
+          discoveryMrkRegion_ =
+              new com.amazonaws.regions.DefaultAwsRegionProviderChain().getRegion();
         } catch (SdkClientException ex) {
-          throw new AwsCryptoException("DiscoveryMrkRegion was not set and Default AWS Region Provider Chain could not load one.", ex);
+          throw new AwsCryptoException(
+              "DiscoveryMrkRegion was not set and Default AWS Region Provider Chain could not load one.",
+              ex);
         }
       }
 
@@ -421,17 +425,21 @@ public final class AwsKmsMrkAwareMasterKeyProvider
     this.regionalClientSupplier_ = supplier;
     // NPE would be thrown via result of extractRegion passed to KMS Client request around line 583.
     // We could refactor extractRegion to handle Strict and Discovery separately,
-    // which would allow us to avoid this potentially un-needed new DefaultAwsRegionProviderChain().getRegion()
+    // which would allow us to avoid this potentially un-needed new
+    // DefaultAwsRegionProviderChain().getRegion()
     // call.
     // Otherwise, we have to have the call.
     if (defaultRegion == null) {
       try {
         defaultRegion = new com.amazonaws.regions.DefaultAwsRegionProviderChain().getRegion();
         if (defaultRegion == null) {
-          throw new AwsCryptoException("Default Region was not set and Default AWS Region Provider Chain could not load one.");
+          throw new AwsCryptoException(
+              "Default Region was not set and Default AWS Region Provider Chain could not load one.");
         }
       } catch (SdkClientException ex) {
-        throw new AwsCryptoException("Default Region was not set and Default AWS Region Provider Chain could not load one.", ex);
+        throw new AwsCryptoException(
+            "Default Region was not set and Default AWS Region Provider Chain could not load one.",
+            ex);
       }
     }
     this.defaultRegion_ = defaultRegion;

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
@@ -192,14 +192,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildDiscovery()
      */
     public AwsKmsMrkAwareMasterKeyProvider buildDiscovery() {
-      String sdkDefaultRegion = getSdkDefaultRegion();
-
       if (defaultRegion_ == null) {
-        defaultRegion_ = sdkDefaultRegion;
-      }
-
-      if (discoveryMrkRegion_ == null) {
-        discoveryMrkRegion_ = sdkDefaultRegion;
+        defaultRegion_ = getSdkDefaultRegion();
       }
 
       final boolean isDiscovery = true;
@@ -251,14 +245,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildStrict(List)
      */
     public AwsKmsMrkAwareMasterKeyProvider buildStrict(List<String> keyIds) {
-      String sdkDefaultRegion = getSdkDefaultRegion();
-
       if (defaultRegion_ == null) {
-        defaultRegion_ = sdkDefaultRegion;
-      }
-
-      if (discoveryMrkRegion_ == null) {
-        discoveryMrkRegion_ = sdkDefaultRegion;
+        defaultRegion_ = getSdkDefaultRegion();
       }
 
       final boolean isDiscovery = false;

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
@@ -49,12 +49,12 @@ public final class AwsKmsMrkAwareMasterKeyProvider
   private final String defaultRegion_;
 
   public static class Builder implements Cloneable {
-    private String defaultRegion_ = getSdkDefaultRegion();
+    private String defaultRegion_ = null;
     private Optional<KmsMasterKeyProvider.RegionalClientSupplier> regionalClientSupplier_ =
         Optional.empty();
     private AWSKMSClientBuilder templateBuilder_ = null;
     private DiscoveryFilter discoveryFilter_ = null;
-    private String discoveryMrkRegion_ = this.defaultRegion_;
+    private String discoveryMrkRegion_ = null;
 
     Builder() {
       // Default access: Don't allow outside classes to extend this class
@@ -192,6 +192,10 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildDiscovery()
      */
     public AwsKmsMrkAwareMasterKeyProvider buildDiscovery() {
+      if (defaultRegion_ == null) {
+        defaultRegion_ = getSdkDefaultRegion();
+      }
+
       final boolean isDiscovery = true;
 
       return new AwsKmsMrkAwareMasterKeyProvider(
@@ -241,6 +245,10 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildStrict(List)
      */
     public AwsKmsMrkAwareMasterKeyProvider buildStrict(List<String> keyIds) {
+      if (defaultRegion_ == null) {
+        defaultRegion_ = getSdkDefaultRegion();
+      }
+
       final boolean isDiscovery = false;
 
       return new AwsKmsMrkAwareMasterKeyProvider(

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
@@ -423,7 +423,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
     }
 
     this.regionalClientSupplier_ = supplier;
-    // NPE would be thrown via result of extractRegion passed to KMS Client request around line 583.
+    // Null Pointer Exception (NPE) would be thrown
+    // via result of extractRegion passed to KMS Client request around line 583.
     // We could refactor extractRegion to handle Strict and Discovery separately,
     // which would allow us to avoid this potentially un-needed new
     // DefaultAwsRegionProviderChain().getRegion()

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
@@ -192,8 +192,14 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildDiscovery()
      */
     public AwsKmsMrkAwareMasterKeyProvider buildDiscovery() {
+      String sdkDefaultRegion = getSdkDefaultRegion();
+
       if (defaultRegion_ == null) {
-        defaultRegion_ = getSdkDefaultRegion();
+        defaultRegion_ = sdkDefaultRegion;
+      }
+
+      if (discoveryMrkRegion_ == null) {
+        discoveryMrkRegion_ = sdkDefaultRegion;
       }
 
       final boolean isDiscovery = true;
@@ -245,8 +251,14 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildStrict(List)
      */
     public AwsKmsMrkAwareMasterKeyProvider buildStrict(List<String> keyIds) {
+      String sdkDefaultRegion = getSdkDefaultRegion();
+
       if (defaultRegion_ == null) {
-        defaultRegion_ = getSdkDefaultRegion();
+        defaultRegion_ = sdkDefaultRegion;
+      }
+
+      if (discoveryMrkRegion_ == null) {
+        discoveryMrkRegion_ = sdkDefaultRegion;
       }
 
       final boolean isDiscovery = false;

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
@@ -352,7 +352,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
     }
 
     this.regionalClientSupplier_ = supplier;
-    // NPE would be thrown via result of extractRegion passed to KMS Client request around line 550.
+    // Null Pointer Exception (NPE) would be thrown
+    // via result of extractRegion passed to KMS Client request around line 550.
     // We could refactor extractRegion to handle Strict and Discovery separately,
     // which would allow us to avoid this potentially un-needed new
     // DefaultAwsRegionProviderChain().getRegion()

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
@@ -47,13 +47,13 @@ public final class AwsKmsMrkAwareMasterKeyProvider
   private final Region defaultRegion_;
 
   public static class Builder implements Cloneable {
-    private Region defaultRegion_ = getSdkDefaultRegion();
+    private Region defaultRegion_ = null;
 
     private Supplier<KmsClientBuilder> builderSupplier_ = null;
     private RegionalClientSupplier regionalClientSupplier_ = null;
 
     private DiscoveryFilter discoveryFilter_ = null;
-    private Region discoveryMrkRegion_ = this.defaultRegion_;
+    private Region discoveryMrkRegion_ = null;
 
     Builder() {
       // Default access: Don't allow outside classes to extend this class
@@ -155,6 +155,10 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildDiscovery()
      */
     public AwsKmsMrkAwareMasterKeyProvider buildDiscovery() {
+      if (defaultRegion_ == null) {
+        defaultRegion_ = getSdkDefaultRegion();
+      }
+
       final boolean isDiscovery = true;
 
       // = compliance/framework/aws-kms/aws-kms-mrk-aware-master-key-provider.txt#2.6
@@ -208,6 +212,10 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildStrict(List)
      */
     public AwsKmsMrkAwareMasterKeyProvider buildStrict(List<String> keyIds) {
+      if (defaultRegion_ == null) {
+        defaultRegion_ = getSdkDefaultRegion();
+      }
+
       final boolean isDiscovery = false;
 
       RegionalClientSupplier clientSupplier = regionalClientSupplier_;

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
@@ -155,14 +155,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildDiscovery()
      */
     public AwsKmsMrkAwareMasterKeyProvider buildDiscovery() {
-      Region sdkDefaultRegion = getSdkDefaultRegion();
-
       if (defaultRegion_ == null) {
-        defaultRegion_ = sdkDefaultRegion;
-      }
-
-      if (discoveryMrkRegion_ == null) {
-        discoveryMrkRegion_ = sdkDefaultRegion;
+        defaultRegion_ = getSdkDefaultRegion();
       }
 
       final boolean isDiscovery = true;
@@ -218,14 +212,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildStrict(List)
      */
     public AwsKmsMrkAwareMasterKeyProvider buildStrict(List<String> keyIds) {
-      Region sdkDefaultRegion = getSdkDefaultRegion();
-
       if (defaultRegion_ == null) {
-        defaultRegion_ = sdkDefaultRegion;
-      }
-
-      if (discoveryMrkRegion_ == null) {
-        discoveryMrkRegion_ = sdkDefaultRegion;
+        defaultRegion_ = getSdkDefaultRegion();
       }
 
       final boolean isDiscovery = false;

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
@@ -19,14 +19,13 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.regions.providers.DefaultAwsRegionProviderChain;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.KmsClientBuilder;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 // = compliance/framework/aws-kms/aws-kms-mrk-aware-master-key-provider.txt#2.5
 // # MUST implement the Master Key Provider Interface (../master-key-
@@ -169,7 +168,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
       }
 
       if (discoveryMrkRegion_ == null) {
-        // The AWS SDK has a default process for evaluating the default Region. This returns null if no
+        // The AWS SDK has a default process for evaluating the default Region. This returns null if
+        // no
         // default region is found. Because a default region _may_ not be needed.
         // Note: Final Null check is at
         // com.amazonaws.encryptionsdk.kmssdkv2.AwsKmsMrkAwareMasterKeyProvider#AwsKmsMrkAwareMasterKeyProvider#L355
@@ -180,7 +180,9 @@ public final class AwsKmsMrkAwareMasterKeyProvider
           // # Default Region MUST be used.
           discoveryMrkRegion_ = new DefaultAwsRegionProviderChain().getRegion();
         } catch (SdkClientException ex) {
-          throw new AwsCryptoException("DiscoveryMrkRegion was not set and Default AWS Region Provider Chain could not load one.", ex);
+          throw new AwsCryptoException(
+              "DiscoveryMrkRegion was not set and Default AWS Region Provider Chain could not load one.",
+              ex);
         }
       }
 
@@ -352,17 +354,21 @@ public final class AwsKmsMrkAwareMasterKeyProvider
     this.regionalClientSupplier_ = supplier;
     // NPE would be thrown via result of extractRegion passed to KMS Client request around line 550.
     // We could refactor extractRegion to handle Strict and Discovery separately,
-    // which would allow us to avoid this potentially un-needed new DefaultAwsRegionProviderChain().getRegion()
+    // which would allow us to avoid this potentially un-needed new
+    // DefaultAwsRegionProviderChain().getRegion()
     // call.
     // Otherwise, we have to have the call.
     if (defaultRegion == null) {
       try {
         defaultRegion = new DefaultAwsRegionProviderChain().getRegion();
         if (defaultRegion == null) {
-          throw new AwsCryptoException("Default Region was not set and Default AWS Region Provider Chain could not load one.");
+          throw new AwsCryptoException(
+              "Default Region was not set and Default AWS Region Provider Chain could not load one.");
         }
       } catch (SdkClientException ex) {
-        throw new AwsCryptoException("Default Region was not set and Default AWS Region Provider Chain could not load one.", ex);
+        throw new AwsCryptoException(
+            "Default Region was not set and Default AWS Region Provider Chain could not load one.",
+            ex);
       }
     }
     this.defaultRegion_ = defaultRegion;
@@ -520,7 +526,7 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      */
     if (isDiscovery_ && requestedKeyArnInfo == null) {
       throw new NoSuchMasterKeyException(
-              // Note: This exception does not make sense to me
+          // Note: This exception does not make sense to me
           "Cannot use AWS KMS identifiers " + "when in discovery mode.");
     }
     // = compliance/framework/aws-kms/aws-kms-mrk-aware-master-key-provider.txt#2.7
@@ -577,7 +583,8 @@ public final class AwsKmsMrkAwareMasterKeyProvider
    *
    * <p>Refactored into a pure function to facilitate testing and ensure correctness.
    */
-  @Nonnull static Region extractRegion(
+  @Nonnull
+  static Region extractRegion(
       @Nonnull final Region defaultRegion,
       final Region discoveryMrkRegion,
       final Optional<String> matchedArn,

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
@@ -155,8 +155,14 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildDiscovery()
      */
     public AwsKmsMrkAwareMasterKeyProvider buildDiscovery() {
+      Region sdkDefaultRegion = getSdkDefaultRegion();
+
       if (defaultRegion_ == null) {
-        defaultRegion_ = getSdkDefaultRegion();
+        defaultRegion_ = sdkDefaultRegion;
+      }
+
+      if (discoveryMrkRegion_ == null) {
+        discoveryMrkRegion_ = sdkDefaultRegion;
       }
 
       final boolean isDiscovery = true;
@@ -212,8 +218,14 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * @see KmsMasterKeyProvider.Builder#buildStrict(List)
      */
     public AwsKmsMrkAwareMasterKeyProvider buildStrict(List<String> keyIds) {
+      Region sdkDefaultRegion = getSdkDefaultRegion();
+
       if (defaultRegion_ == null) {
-        defaultRegion_ = getSdkDefaultRegion();
+        defaultRegion_ = sdkDefaultRegion;
+      }
+
+      if (discoveryMrkRegion_ == null) {
+        discoveryMrkRegion_ = sdkDefaultRegion;
       }
 
       final boolean isDiscovery = false;

--- a/src/test/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProviderTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProviderTest.java
@@ -226,11 +226,11 @@ public class AwsKmsMrkAwareMasterKeyProviderTest {
     @Test
     public void always_need_a_region() {
       assertThrows(
-              AwsCryptoException.class,
-              () ->
-                      AwsKmsMrkAwareMasterKeyProvider.builder()
-                              .withDefaultRegion(null)
-                              .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574"));
+          AwsCryptoException.class,
+          () ->
+              AwsKmsMrkAwareMasterKeyProvider.builder()
+                  .withDefaultRegion(null)
+                  .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574"));
       AwsKmsMrkAwareMasterKeyProvider.builder()
           .withDefaultRegion("us-east-1")
           .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574");
@@ -243,14 +243,14 @@ public class AwsKmsMrkAwareMasterKeyProviderTest {
     // # obtained initialization MUST fail.
     public void discovery_region_can_not_be_null() {
       assertThrows(
-              IllegalArgumentException.class,
-              () ->
-                      AwsKmsMrkAwareMasterKeyProvider.builder()
-                              // need to force the default region to `null`
-                              // otherwise it may pick one up from the environment.
-                              .withDefaultRegion(null)
-                              .withDiscoveryMrkRegion(null)
-                              .buildDiscovery());
+          IllegalArgumentException.class,
+          () ->
+              AwsKmsMrkAwareMasterKeyProvider.builder()
+                  // need to force the default region to `null`
+                  // otherwise it may pick one up from the environment.
+                  .withDefaultRegion(null)
+                  .withDiscoveryMrkRegion(null)
+                  .buildDiscovery());
     }
 
     @Test

--- a/src/test/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProviderTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProviderTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.spy;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.encryptionsdk.*;
-import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.exception.CannotUnwrapDataKeyException;
 import com.amazonaws.encryptionsdk.exception.NoSuchMasterKeyException;
 import com.amazonaws.encryptionsdk.exception.UnsupportedProviderException;
@@ -225,33 +224,23 @@ public class AwsKmsMrkAwareMasterKeyProviderTest {
 
     @Test
     public void always_need_a_region() {
-      assertThrows(
-          AwsCryptoException.class,
-          () ->
-              AwsKmsMrkAwareMasterKeyProvider.builder()
-                  .withDefaultRegion(null)
-                  .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574"));
-
       AwsKmsMrkAwareMasterKeyProvider.builder()
-          .withDefaultRegion("us-east-1")
+          // If default region is set to `null` or not configured
+          // it will pick one up from the environment
+          .withDefaultRegion(null)
           .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574");
     }
 
     @Test
-    // = compliance/framework/aws-kms/aws-kms-mrk-aware-master-key-provider.txt#2.6
-    // = type=test
-    // # If an AWS SDK Default Region can not be
-    // # obtained initialization MUST fail.
     public void discovery_region_can_not_be_null() {
-      assertThrows(
-          IllegalArgumentException.class,
-          () ->
-              AwsKmsMrkAwareMasterKeyProvider.builder()
-                  // need to force the default region to `null`
-                  // otherwise it may pick one up from the environment.
-                  .withDefaultRegion(null)
-                  .withDiscoveryMrkRegion(null)
-                  .buildDiscovery());
+      AwsKmsMrkAwareMasterKeyProvider.builder()
+          // If default region is set to `null` or not configured
+          // it will pick one up from the environment
+          .withDefaultRegion(null)
+          // In discovery mode if a default MRK Region is not configured the AWS SDK
+          // Default Region MUST be used.
+          .withDiscoveryMrkRegion(null)
+          .buildDiscovery();
     }
 
     @Test

--- a/src/test/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProviderTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProviderTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.spy;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.encryptionsdk.*;
+import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.exception.CannotUnwrapDataKeyException;
 import com.amazonaws.encryptionsdk.exception.NoSuchMasterKeyException;
 import com.amazonaws.encryptionsdk.exception.UnsupportedProviderException;
@@ -224,23 +225,32 @@ public class AwsKmsMrkAwareMasterKeyProviderTest {
 
     @Test
     public void always_need_a_region() {
+      assertThrows(
+              AwsCryptoException.class,
+              () ->
+                      AwsKmsMrkAwareMasterKeyProvider.builder()
+                              .withDefaultRegion(null)
+                              .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574"));
       AwsKmsMrkAwareMasterKeyProvider.builder()
-          // If default region is set to `null` or not configured
-          // it will pick one up from the environment
-          .withDefaultRegion(null)
+          .withDefaultRegion("us-east-1")
           .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574");
     }
 
     @Test
+    // = compliance/framework/aws-kms/aws-kms-mrk-aware-master-key-provider.txt#2.6
+    // = type=test
+    // # If an AWS SDK Default Region can not be
+    // # obtained initialization MUST fail.
     public void discovery_region_can_not_be_null() {
-      AwsKmsMrkAwareMasterKeyProvider.builder()
-          // If default region is set to `null` or not configured
-          // it will pick one up from the environment
-          .withDefaultRegion(null)
-          // In discovery mode if a default MRK Region is not configured the AWS SDK
-          // Default Region MUST be used.
-          .withDiscoveryMrkRegion(null)
-          .buildDiscovery();
+      assertThrows(
+              IllegalArgumentException.class,
+              () ->
+                      AwsKmsMrkAwareMasterKeyProvider.builder()
+                              // need to force the default region to `null`
+                              // otherwise it may pick one up from the environment.
+                              .withDefaultRegion(null)
+                              .withDiscoveryMrkRegion(null)
+                              .buildDiscovery());
     }
 
     @Test

--- a/src/test/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProviderTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProviderTest.java
@@ -238,11 +238,11 @@ public class AwsKmsMrkAwareMasterKeyProviderTest {
     @DisplayName("Precondition: A region is required to contact AWS KMS.")
     public void always_need_a_region() {
       assertThrows(
-              AwsCryptoException.class,
-              () ->
-                      AwsKmsMrkAwareMasterKeyProvider.builder()
-                              .defaultRegion(null)
-                              .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574"));
+          AwsCryptoException.class,
+          () ->
+              AwsKmsMrkAwareMasterKeyProvider.builder()
+                  .defaultRegion(null)
+                  .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574"));
       AwsKmsMrkAwareMasterKeyProvider.builder()
           .defaultRegion(Region.US_EAST_1)
           .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574");
@@ -255,14 +255,14 @@ public class AwsKmsMrkAwareMasterKeyProviderTest {
     // # obtained initialization MUST fail.
     public void discovery_region_can_not_be_null() {
       assertThrows(
-              AwsCryptoException.class,
-              () ->
-                      AwsKmsMrkAwareMasterKeyProvider.builder()
-                              // need to force the default region to `null`
-                              // otherwise it may pick one up from the environment.
-                              .defaultRegion(null)
-                              .discoveryMrkRegion(null)
-                              .buildDiscovery());
+          AwsCryptoException.class,
+          () ->
+              AwsKmsMrkAwareMasterKeyProvider.builder()
+                  // need to force the default region to `null`
+                  // otherwise it may pick one up from the environment.
+                  .defaultRegion(null)
+                  .discoveryMrkRegion(null)
+                  .buildDiscovery());
     }
 
     @Test

--- a/src/test/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProviderTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProviderTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import com.amazonaws.encryptionsdk.*;
-import com.amazonaws.encryptionsdk.exception.AwsCryptoException;
 import com.amazonaws.encryptionsdk.exception.CannotUnwrapDataKeyException;
 import com.amazonaws.encryptionsdk.exception.NoSuchMasterKeyException;
 import com.amazonaws.encryptionsdk.exception.UnsupportedProviderException;
@@ -235,35 +234,24 @@ public class AwsKmsMrkAwareMasterKeyProviderTest {
     }
 
     @Test
-    @DisplayName("Precondition: A region is required to contact AWS KMS.")
     public void always_need_a_region() {
-      assertThrows(
-          AwsCryptoException.class,
-          () ->
-              AwsKmsMrkAwareMasterKeyProvider.builder()
-                  .defaultRegion(null)
-                  .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574"));
-
       AwsKmsMrkAwareMasterKeyProvider.builder()
-          .defaultRegion(Region.US_EAST_1)
+          // If default region is set to `null` or not configured
+          // it will pick one up from the environment
+          .defaultRegion(null)
           .buildStrict("mrk-edb7fe6942894d32ac46dbb1c922d574");
     }
 
     @Test
-    // = compliance/framework/aws-kms/aws-kms-mrk-aware-master-key-provider.txt#2.6
-    // = type=test
-    // # If an AWS SDK Default Region can not be
-    // # obtained initialization MUST fail.
     public void discovery_region_can_not_be_null() {
-      assertThrows(
-          IllegalArgumentException.class,
-          () ->
-              AwsKmsMrkAwareMasterKeyProvider.builder()
-                  // need to force the default region to `null`
-                  // otherwise it may pick one up from the environment.
-                  .defaultRegion(null)
-                  .discoveryMrkRegion(null)
-                  .buildDiscovery());
+      AwsKmsMrkAwareMasterKeyProvider.builder()
+          // If default region is set to `null` or not configured
+          // it will pick one up from the environment
+          .defaultRegion(null)
+          // In discovery mode if a default MRK Region is not configured the AWS SDK
+          // Default Region MUST be used.
+          .discoveryMrkRegion(null)
+          .buildDiscovery();
     }
 
     @Test


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/aws/aws-encryption-sdk-java/issues/1768

*Description of changes:*

- Defer calling `getSdkDefaultRegion()` only if no default region is provided.
- This change only resolve the default region from `DefaultAwsRegionProviderChain` if default region is null or not configured.
- Furthermore, `_defaultRegion` and `_discoveryMrkRegion` will always have non-null region values during build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

