### PR TITLE
chore(pom.xml): update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,8 +54,8 @@
     <dependencies>
         <dependency>
             <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>1.12.394</version>
+            <artifactId>aws-java-sdk-kms</artifactId>
+            <version>1.12.531</version>
             <optional>true</optional>
         </dependency>
 
@@ -75,22 +75,6 @@
             <groupId>software.amazon.cryptography</groupId>
             <artifactId>TestAwsCryptographicMaterialProviders</artifactId>
             <version>1.0-SNAPSHOT</version>
-            <optional>true</optional>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>software.amazon.smithy.dafny</groupId>
-            <artifactId>conversion</artifactId>
-            <version>0.1</version>
-            <optional>true</optional>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.dafny</groupId>
-            <artifactId>DafnyRuntime</artifactId>
-            <version>4.2.0</version>
             <optional>true</optional>
             <scope>test</scope>
         </dependency>
@@ -129,15 +113,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>annotations</artifactId>
-            <version>3.0.1</version>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs-annotations</artifactId>
+            <version>4.7.3</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/aws/aws-encryption-sdk-java/issues/1892

*Description of changes:*

_Update dependencies:_
   1. `com.amazonaws.aws-java-sdk-kms`: Pull only the KMS module from AWS SDK v1.
   2. `org.dafny.DafnyRuntime` and `software.amazon.smithy.dafny.smithy`: Remove the Dafny related dependencies that are already added to the compile and run class paths.
   3. `com.github.spotbugs.spotbugs-annotations`: Migrate to [spotbugs dependencies](https://spotbugs.readthedocs.io/en/stable/migration.html).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

