### PR TITLE
chore: deprecate getMasterKeyIds() in CryptoResult

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/CryptoResult.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/CryptoResult.java
@@ -69,6 +69,7 @@ public class CryptoResult<T, K extends MasterKey<K>> {
   }
 
   /** Convenience method for retrieving the keyIds in the results from {@link #getMasterKeys()}. */
+  @Deprecated
   public List<String> getMasterKeyIds() {
     final List<String> result = new ArrayList<>(masterKeys_.size());
     for (final MasterKey<K> mk : masterKeys_) {

--- a/src/main/java/com/amazonaws/encryptionsdk/internal/DecryptionHandler.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/DecryptionHandler.java
@@ -890,7 +890,9 @@ public class DecryptionHandler<K extends MasterKey<K>> implements MessageCryptoH
 
   @Override
   public List<K> getMasterKeys() {
-    return Collections.singletonList(dataKey_.getMasterKey());
+    return dataKey_.getMasterKey() == null
+        ? Collections.emptyList()
+        : Collections.singletonList(dataKey_.getMasterKey());
   }
 
   @Override

--- a/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoIntegrationTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoIntegrationTest.java
@@ -113,21 +113,21 @@ public class AwsCryptoIntegrationTest {
         crypto.encryptData(kmsKeyring, EXAMPLE_DATA, encryptionContext);
 
     List<?> masterKeys = encryptResult.getMasterKeys();
+    List<String> masterKeyIds = encryptResult.getMasterKeyIds();
     // Assert CryptoResult returns empty list if keyrings are used.
     assert masterKeys.size() == 0;
+    assert masterKeyIds.isEmpty();
 
     final byte[] ciphertext = encryptResult.getResult();
 
     // Decrypt the data
-    final CryptoResult<byte[], ?> decryptResult = crypto.decryptData(kmsKeyring, ciphertext);
+    final CryptoResult<byte[], ?> decryptResult =
+        crypto.decryptData(kmsKeyring, ciphertext, encryptionContext);
+    masterKeys = decryptResult.getMasterKeys();
+    masterKeyIds = decryptResult.getMasterKeyIds();
+    // Assert CryptoResult returns empty list if keyrings are used.
     assert masterKeys.size() == 0;
-
-    // Verify that the encryption context in the result contains the
-    // encryption context supplied to the encryptData method.
-    if (!encryptionContext.entrySet().stream()
-        .allMatch(e -> e.getValue().equals(decryptResult.getEncryptionContext().get(e.getKey())))) {
-      throw new IllegalStateException("Wrong Encryption Context!");
-    }
+    assert masterKeyIds.isEmpty();
 
     // Verify that the decrypted plaintext matches the original plaintext
     assert Arrays.equals(decryptResult.getResult(), EXAMPLE_DATA);

--- a/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoIntegrationTest.java
+++ b/src/test/java/com/amazonaws/encryptionsdk/AwsCryptoIntegrationTest.java
@@ -115,7 +115,7 @@ public class AwsCryptoIntegrationTest {
     List<?> masterKeys = encryptResult.getMasterKeys();
     List<String> masterKeyIds = encryptResult.getMasterKeyIds();
     // Assert CryptoResult returns empty list if keyrings are used.
-    assert masterKeys.size() == 0;
+    assert masterKeys.isEmpty();
     assert masterKeyIds.isEmpty();
 
     final byte[] ciphertext = encryptResult.getResult();
@@ -126,7 +126,7 @@ public class AwsCryptoIntegrationTest {
     masterKeys = decryptResult.getMasterKeys();
     masterKeyIds = decryptResult.getMasterKeyIds();
     // Assert CryptoResult returns empty list if keyrings are used.
-    assert masterKeys.size() == 0;
+    assert masterKeys.isEmpty();
     assert masterKeyIds.isEmpty();
 
     // Verify that the decrypted plaintext matches the original plaintext


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- deprecate getMasterKeyIds() in CryptoResult and return empty list if keyring is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

