### PR TITLE
chore(JavaDocs): detail thread saftey of SDK Client Builders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,14 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+<!--    Uncomment the next block for development with TestVectorsAwsCryptographicMaterialProviders in local mvn -->
+<!--    <repositories>-->
+<!--        <repository>-->
+<!--            <id>localRepository</id>-->
+<!--            <name>localRepository</name>-->
+<!--            <url>file://${user.home}/.m2/repository/</url>-->
+<!--        </repository>-->
+<!--    </repositories>-->
 
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/AwsKmsMrkAwareMasterKeyProvider.java
@@ -172,6 +172,10 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * <p>This method will overwrite any credentials set using {@link
      * #withCredentials(AWSCredentialsProvider)}.
      *
+     * <p>WARNING: {@link AWSKMSClientBuilder}s are NOT thread safe. If {@link KmsMasterKeyProvider}
+     * is going to be used concurrently, a proper supplier MUST be provided, or use a {@link
+     * #withCustomClientFactory(KmsMasterKeyProvider.RegionalClientSupplier)}
+     *
      * @see KmsMasterKeyProvider.Builder#withClientBuilder(AWSKMSClientBuilder)
      */
     public AwsKmsMrkAwareMasterKeyProvider.Builder withClientBuilder(AWSKMSClientBuilder builder) {

--- a/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kms/KmsMasterKeyProvider.java
@@ -173,6 +173,10 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
      * <p>This method will overwrite any credentials set using {@link
      * #withCredentials(AWSCredentialsProvider)}.
      *
+     * <p>WARNING: {@link AWSKMSClientBuilder}s are NOT thread safe. If {@link KmsMasterKeyProvider}
+     * is going to be used concurrently, a proper supplier MUST be provided, or use a {@link
+     * #withCustomClientFactory(KmsMasterKeyProvider.RegionalClientSupplier)}
+     *
      * @param builder
      * @return
      */

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/AwsKmsMrkAwareMasterKeyProvider.java
@@ -131,6 +131,10 @@ public final class AwsKmsMrkAwareMasterKeyProvider
      * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient}
      * interface.
      *
+     * <p>WARNING: {@link KmsClientBuilder}s are NOT thread safe. If {@link KmsMasterKeyProvider} is
+     * going to be used concurrently, a proper supplier MUST be provided, or use a {@link
+     * #customRegionalClientSupplier(RegionalClientSupplier)}
+     *
      * @see KmsMasterKeyProvider.Builder#builderSupplier(Supplier)
      */
     public Builder builderSupplier(Supplier<KmsClientBuilder> supplier) {

--- a/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/KmsMasterKeyProvider.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/KmsMasterKeyProvider.java
@@ -116,6 +116,10 @@ public class KmsMasterKeyProvider extends MasterKeyProvider<KmsMasterKey> implem
      * <p>Note: The AWS Encryption SDK for Java does not support the {@code KmsAsyncClient}
      * interface.
      *
+     * <p>WARNING: {@link KmsClientBuilder}s are NOT thread safe. If {@link KmsMasterKeyProvider} is
+     * going to be used concurrently, a proper supplier MUST be provided, or use a {@link
+     * #customRegionalClientSupplier(RegionalClientSupplier)}
+     *
      * @param supplier Should return a new {@link KmsClientBuilder} on each invocation.
      * @return
      */


### PR DESCRIPTION
*Issue #, if available:*

The AWS SDK for Java's Service Client builders are not thread safe.
Crypto Tools customer's have reported odd,
occasionally disruptive behavior when using them 
in a concurrent setting.

As such, 
Crypto Tools should make it clear how to set a KMS Client
in a thread safe manner.

Which can be done via the Regional Client Supplier.

Additionally, 
we can improve on the Java Documentation to highlight that
Builders are not thread safe,
and that proper Builder suppliers MUST be used,
or customers SHOULD use the alternative client configuration methods.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

