### PR TITLE
fix: guard against null version and change property name to avoid conflicts

### DIFF
--- a/src/main/java/com/amazonaws/encryptionsdk/internal/VersionInfo.java
+++ b/src/main/java/com/amazonaws/encryptionsdk/internal/VersionInfo.java
@@ -14,6 +14,7 @@
 package com.amazonaws.encryptionsdk.internal;
 
 import java.io.IOException;
+import java.util.Objects;
 import java.util.Properties;
 
 /** This class specifies the versioning system for the AWS KMS encryption client. */
@@ -44,7 +45,11 @@ public class VersionInfo {
       final Properties properties = new Properties();
       final ClassLoader loader = VersionInfo.class.getClassLoader();
       properties.load(loader.getResourceAsStream("project.properties"));
-      return properties.getProperty("version");
+      String maybeVersion = properties.getProperty("esdkVersion");
+      // In some cases, another dependency MAY also define a project.properties file,
+      // which MAY be loaded before the ESDK's. In this case, the version property
+      // MAY NOT exist, which causes an NPE later on.
+      return Objects.requireNonNullElse(maybeVersion, UNKNOWN_VERSION);
     } catch (final IOException ex) {
       return UNKNOWN_VERSION;
     }

--- a/src/main/resources/project.properties
+++ b/src/main/resources/project.properties
@@ -1,1 +1,1 @@
-version=${project.version}
+esdkVersion=${project.version}


### PR DESCRIPTION

*Issue #, if available:* https://github.com/aws/aws-encryption-sdk-java/issues/2114

*Description of changes:* See issue. Also, change the property name from `version` to `esdkVersion` to avoid the possibility of picking up the `version` property from another project which has been loaded before the ESDK's. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

