### PR TITLE
chore: move release to Nexus Central

### DIFF
--- a/cfn/ci_cd.yml
+++ b/cfn/ci_cd.yml
@@ -376,6 +376,7 @@ Resources:
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-Release-haLIjZ",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Maven-GPG-Keys-Release-Credentials-WgJanS",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-User-Token-zK61bM",
+                "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Sonatype-Central-Portal-XrYUs2",
                 "arn:aws:secretsmanager:us-west-2:${AWS::AccountId}:secret:Github/aws-crypto-tools-ci-bot-AGUB3U"
               ],
               "Action": "secretsmanager:GetSecretValue"

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -9,8 +9,8 @@ env:
   secrets-manager:
     GPG_KEY: Maven-GPG-Keys-Release-Credentials:Keyname
     GPG_PASS: Maven-GPG-Keys-Release-Credentials:Passphrase
-    SONA_USERNAME: Sonatype-User-Token:username
-    SONA_PASSWORD: Sonatype-User-Token:password
+    SONA_USERNAME: Sonatype-Central-Portal:Username
+    SONA_PASSWORD: Sonatype-Central-Portal:Password
 
 phases:
   install:

--- a/codebuild/release/settings.xml
+++ b/codebuild/release/settings.xml
@@ -13,7 +13,7 @@ SPDX-License-Identifier: Apache-2.0
       <password>${codeartifact.token}</password>
     </server>
     <server>
-      <id>sonatype-nexus-staging</id>
+      <id>central</id>
       <username>${sonatype.username}</username>
       <password>${sonatype.password}</password>
     </server>

--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,7 @@
                 <groupId>com.coveo</groupId>
                 <artifactId>fmt-maven-plugin</artifactId>
                 <version>2.13</version>
+
                 <!-- Configure no goals. -->
                 <!--Until our CI builds no longer depend on Java 8, skip this during build.-->
                 <!--We instead manually check this in Java 11 environments to block builds, -->
@@ -338,13 +339,12 @@
                     </plugin>
 
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>sonatype-nexus-staging</serverId>
-                            <nexusUrl>https://aws.oss.sonatype.org</nexusUrl>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* The way we publish to Maven is being deprecated. Move to the latest. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

