### PR TITLE
working on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
           project-name: AWS-ESDK-Java-CI
           buildspec-override: codebuild/ci/static-analysis.yml
           compute-type-override: BUILD_GENERAL1_MEDIUM
-          image-override: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+          image-override: "aws/codebuild/amazonlinux-x86_64-standard:5.0"
   vectorTests:
     name: Vector Tests
     runs-on: ubuntu-latest
@@ -35,10 +35,10 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - distribution: openjdk
-            image: "aws/codebuild/standard:3.0"
+          # - distribution: openjdk
+          #   image: "aws/codebuild/amazonlinux-x86_64-standard:5.0"
           - distribution: corretto
-            image: "aws/codebuild/amazonlinux2-x86_64-standard:3.0" # Corretto only runs on AL2
+            image: "aws/codebuild/amazonlinux-x86_64-standard:5.0" # Corretto only runs on AL2
         version: [ 8, 11 ]
     steps:
       - name: Configure AWS Credentials
@@ -65,10 +65,10 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - distribution: openjdk
-            image: "aws/codebuild/standard:3.0"
+          # - distribution: openjdk
+          #   image: "aws/codebuild/standard:3.0"
           - distribution: corretto
-            image: "aws/codebuild/amazonlinux2-x86_64-standard:3.0" # Corretto only runs on AL2
+            image: "aws/codebuild/amazonlinux-x86_64-standard:5.0" # Corretto only runs on AL2
         version: [ 8, 11 ]
     steps:
       - name: Configure AWS Credentials
@@ -95,10 +95,10 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - distribution: openjdk
-            image: "aws/codebuild/standard:3.0"
+          # - distribution: openjdk
+          #   image: "aws/codebuild/standard:3.0"
           - distribution: corretto
-            image: "aws/codebuild/amazonlinux2-x86_64-standard:3.0" # Corretto only runs on AL2
+            image: "aws/codebuild/amazonlinux-x86_64-standard:5.0" # Corretto only runs on AL2
         version: [ 8, 11 ]
     steps:
       - name: Configure AWS Credentials
@@ -126,10 +126,10 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - distribution: openjdk
-            image: "aws/codebuild/standard:3.0"
+          # - distribution: openjdk
+          #   image: "aws/codebuild/standard:3.0"
           - distribution: corretto
-            image: "aws/codebuild/amazonlinux2-x86_64-standard:3.0" # Corretto only runs on AL2
+            image: "aws/codebuild/amazonlinux-x86_64-standard:5.0" # Corretto only runs on AL2
         version: [ 8, 11 ]
     steps:
       - name: Configure AWS Credentials
@@ -166,7 +166,7 @@ jobs:
           project-name: AWS-ESDK-Java-CI
           buildspec-override: codebuild/ci/release-ci.yml
           compute-type-override: BUILD_GENERAL1_LARGE
-          image-override: aws/codebuild/standard:3.0
+          image-override: "aws/codebuild/amazonlinux-x86_64-standard:5.0"
           env-vars-for-codebuild: GITHUB_EVENT_NAME
         env:
           GITHUB_EVENT_NAME: $GITHUB_EVENT_NAME
@@ -178,10 +178,10 @@ jobs:
       fail-fast: true
       matrix:
         platform:
-          - distribution: openjdk
-            image: "aws/codebuild/standard:3.0"
+          # - distribution: openjdk
+          #   image: "aws/codebuild/standard:3.0"
           - distribution: corretto
-            image: "aws/codebuild/amazonlinux2-x86_64-standard:3.0" # Corretto only runs on AL2
+            image: "aws/codebuild/amazonlinux-x86_64-standard:5.0" # Corretto only runs on AL2
         version: [ 8, 11 ]
     steps:
       - name: Configure AWS Credentials

--- a/codebuild/ci/release-ci.yml
+++ b/codebuild/ci/release-ci.yml
@@ -16,7 +16,7 @@ env:
 phases:
   install:
     runtime-versions:
-      java: openjdk11
+      java: corretto11
     commands:
       - git submodule update --init submodules/MaterialProviders
       # Get Dafny

--- a/codebuild/release/release.yml
+++ b/codebuild/release/release.yml
@@ -12,25 +12,25 @@ batch:
     buildspec: codebuild/release/release-staging.yml
 
 # Validate CodeArtifact with supported JDK and Corretto
-  - identifier: validate_staging_release_openjdk8
-    depend-on:
-      - release_staging
-    buildspec: codebuild/release/validate-staging.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: openjdk8
-        JAVA_NUMERIC_VERSION: 8
-      image: aws/codebuild/standard:3.0
+  # - identifier: validate_staging_release_openjdk8
+  #   depend-on:
+  #     - release_staging
+  #   buildspec: codebuild/release/validate-staging.yml
+  #   env:
+  #     variables:
+  #       JAVA_ENV_VERSION: openjdk8
+  #       JAVA_NUMERIC_VERSION: 8
+  #     image: aws/codebuild/standard:3.0
 
-  - identifier: validate_staging_release_openjdk11
-    depend-on:
-      - release_staging
-    buildspec: codebuild/release/validate-staging.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: openjdk11
-        JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/standard:3.0
+  # - identifier: validate_staging_release_openjdk11
+  #   depend-on:
+  #     - release_staging
+  #   buildspec: codebuild/release/validate-staging.yml
+  #   env:
+  #     variables:
+  #       JAVA_ENV_VERSION: openjdk11
+  #       JAVA_NUMERIC_VERSION: 11
+  #     image: aws/codebuild/standard:3.0
 
   - identifier: validate_staging_release_corretto8
     depend-on:
@@ -40,7 +40,7 @@ batch:
       variables:
         JAVA_ENV_VERSION: corretto8
         JAVA_NUMERIC_VERSION: 8
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+      image: "aws/codebuild/amazonlinux-x86_64-standard:5.0"
 
   - identifier: validate_staging_release_corretto11
     depend-on:
@@ -50,14 +50,14 @@ batch:
       variables:
         JAVA_ENV_VERSION: corretto11
         JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+      image: "aws/codebuild/amazonlinux-x86_64-standard:5.0"
 
 # Version Project
   - identifier: version
     depend-on:
       - release_staging
-      - validate_staging_release_openjdk8
-      - validate_staging_release_openjdk11
+      # - validate_staging_release_openjdk8
+      # - validate_staging_release_openjdk11
       - validate_staging_release_corretto8
       - validate_staging_release_corretto11
     buildspec: codebuild/release/version.yml
@@ -77,25 +77,25 @@ batch:
     buildspec: codebuild/release/artifact-hunt.yml
 
 # Validate Maven Central with supported JDK and Corretto
-  - identifier: validate_prod_release_openjdk8
-    depend-on:
-      - artifact_hunt
-    buildspec: codebuild/release/validate-prod.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: openjdk8
-        JAVA_NUMERIC_VERSION: 8
-      image: aws/codebuild/standard:3.0
+  # - identifier: validate_prod_release_openjdk8
+  #   depend-on:
+  #     - artifact_hunt
+  #   buildspec: codebuild/release/validate-prod.yml
+  #   env:
+  #     variables:
+  #       JAVA_ENV_VERSION: openjdk8
+  #       JAVA_NUMERIC_VERSION: 8
+  #     image: aws/codebuild/standard:3.0
 
-  - identifier: validate_prod_release_openjdk11
-    depend-on:
-      - artifact_hunt
-    buildspec: codebuild/release/validate-prod.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: openjdk11
-        JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/standard:3.0
+  # - identifier: validate_prod_release_openjdk11
+  #   depend-on:
+  #     - artifact_hunt
+  #   buildspec: codebuild/release/validate-prod.yml
+  #   env:
+  #     variables:
+  #       JAVA_ENV_VERSION: openjdk11
+  #       JAVA_NUMERIC_VERSION: 11
+  #     image: aws/codebuild/standard:3.0
 
   - identifier: validate_prod_release_corretto8
     depend-on:
@@ -105,7 +105,7 @@ batch:
       variables:
         JAVA_ENV_VERSION: corretto8
         JAVA_NUMERIC_VERSION: 8
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+      image: "aws/codebuild/amazonlinux-x86_64-standard:5.0"
 
   - identifier: validate_prod_release_corretto11
     depend-on:
@@ -115,13 +115,13 @@ batch:
       variables:
         JAVA_ENV_VERSION: corretto11
         JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+      image: "aws/codebuild/amazonlinux-x86_64-standard:5.0"
 
 # Upload Artifacts
   - identifier: upload_artifacts
     depend-on:
-      - validate_prod_release_openjdk8
-      - validate_prod_release_openjdk11
+      # - validate_prod_release_openjdk8
+      # - validate_prod_release_openjdk11
       - validate_prod_release_corretto8
       - validate_prod_release_corretto11
     buildspec: codebuild/release/upload_artifacts.yml
@@ -139,4 +139,4 @@ batch:
       variables:
         JAVA_ENV_VERSION: coretto11
         JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/amazonlinux2-x86_64-standard:3.0
+      image: "aws/codebuild/amazonlinux-x86_64-standard:5.0"


### PR DESCRIPTION
Codebuild no longer supports OpenJDK as a built in Java runtime.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

