### PR TITLE
chore(examples): use OAEP_SHA384_MGF1 in raw RSA examples

### DIFF
--- a/src/examples/java/com/amazonaws/crypto/examples/keyrings/RawRsaKeyringExample.java
+++ b/src/examples/java/com/amazonaws/crypto/examples/keyrings/RawRsaKeyringExample.java
@@ -71,7 +71,7 @@ public class RawRsaKeyringExample {
         CreateRawRsaKeyringInput.builder()
             .keyName("rsa-key")
             .keyNamespace("rsa-keyring")
-            .paddingScheme(PaddingScheme.PKCS1)
+            .paddingScheme(PaddingScheme.OAEP_SHA384_MGF1)
             .publicKey(publicKeyBytes)
             .build();
     final IKeyring encryptingKeyring = matProv.CreateRawRsaKeyring(encryptingKeyringInput);
@@ -94,7 +94,7 @@ public class RawRsaKeyringExample {
         CreateRawRsaKeyringInput.builder()
             .keyName("rsa-key")
             .keyNamespace("rsa-keyring")
-            .paddingScheme(PaddingScheme.PKCS1)
+            .paddingScheme(PaddingScheme.OAEP_SHA384_MGF1)
             .privateKey(privateKeyBytes)
             .build();
     final IKeyring decryptingKeyring = matProv.CreateRawRsaKeyring(decryptingKeyringInput);


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* `PKCS1` should be avoided in favor of OAEP based padding schemes. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.

